### PR TITLE
Avoid txn copy causing crash due to repeated deallocation

### DIFF
--- a/silkrpc/core/executor.cpp
+++ b/silkrpc/core/executor.cpp
@@ -80,9 +80,9 @@ asio::awaitable<ExecutionResult> Executor::call(const silkworm::Block& block, co
     SILKRPC_DEBUG << "Executor::call block: " << block.header.number << " txn: " << &txn << " gas: " << gas << " start\n";
 
     const auto exec_result = co_await asio::async_compose<decltype(asio::use_awaitable), void(ExecutionResult)>(
-        [this, block, txn, gas](auto&& self) {
+        [this, &block, &txn, gas](auto&& self) {
             SILKRPC_TRACE << "Executor::call post block: " << block.header.number << " txn: " << &txn << " gas: " << gas << "\n";
-            asio::post(thread_pool_, [this, block, txn, gas, self = std::move(self)]() mutable {
+            asio::post(thread_pool_, [this, &block, &txn, gas, self = std::move(self)]() mutable {
                 silkworm::IntraBlockState state{buffer_};
                 silkworm::EVM evm{block, state, config_};
 


### PR DESCRIPTION
Fixes #90 