### PR TITLE
Fix for issue #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ Once the prerequisites are installed, there are convenience [bash](https://www.g
 ```
 The resulting build folders are `build_[gcc, clang]_[debug, release]` according to your choice.
 
-You can also perform the build step-by-step manually, just bootstrap cmake by running
+To enable parallel compilation, set the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable to the desired value ([see](https://cmake.org/cmake/help/latest/manual/cmake.1.html)). 
+
+For example, to have 4 concurrent compile processes, insert in `.bashrc` file the following line
+```
+export CMAKE_BUILD_PARALLEL_LEVEL=4
+```
+
+You can also perform the build step-by-step manually, just bootstrap cmake by running.
+
 ```
 mkdir build_gcc_release
 cd build_gcc_release

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Once the prerequisites are installed, there are convenience [bash](https://www.g
 ```
 The resulting build folders are `build_[gcc, clang]_[debug, release]` according to your choice.
 
-To enable parallel compilation, set the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable to the desired value ([see](https://cmake.org/cmake/help/latest/manual/cmake.1.html)). 
+To enable parallel compilation, set the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable to the desired value as described [here](https://cmake.org/cmake/help/latest/manual/cmake.1.html#build-a-project). 
 
-For example, to have 4 concurrent compile processes, insert in `.bashrc` file the following line
+For example, in order to have 4 concurrent compile processes, insert in `.bashrc` file the following line
 ```
 export CMAKE_BUILD_PARALLEL_LEVEL=4
 ```
 
-You can also perform the build step-by-step manually, just bootstrap cmake by running.
+You can also perform the build step-by-step manually, just bootstrap cmake by running
 
 ```
 mkdir build_gcc_release

--- a/build_clang_coverage.sh
+++ b/build_clang_coverage.sh
@@ -2,7 +2,7 @@
 
 PROJECT_DIR=$PWD
 cd build_clang_coverage
-cmake --build . --parallel
+cmake --build .
 cmd/unit_test
 mv default.profraw unit_test.profraw
 llvm-profdata merge *.profraw -o profdata

--- a/build_clang_debug.sh
+++ b/build_clang_debug.sh
@@ -2,5 +2,5 @@
 
 PROJECT_DIR=$PWD
 cd build_clang_debug
-cmake --build . --parallel
+cmake --build .
 cmd/unit_test

--- a/build_clang_release.sh
+++ b/build_clang_release.sh
@@ -2,5 +2,5 @@
 
 PROJECT_DIR=$PWD
 cd build_clang_release
-cmake --build . --parallel
+cmake --build .
 cmd/unit_test

--- a/build_gcc_debug.sh
+++ b/build_gcc_debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd build_gcc_debug
-cmake --build . --parallel
+cmake --build .
 cmd/unit_test

--- a/build_gcc_release.sh
+++ b/build_gcc_release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd build_gcc_release
-cmake --build . --parallel
+cmake --build .
 cmd/unit_test

--- a/rebuild_clang_coverage.sh
+++ b/rebuild_clang_coverage.sh
@@ -5,8 +5,5 @@ rm -fr build_clang_coverage
 mkdir build_clang_coverage
 cd build_clang_coverage
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=$PROJECT_DIR/cmake/clang-libcxx20-fpic.cmake -DSILKRPC_CLANG_COVERAGE=ON ..
-cmake --build . --parallel
-cmd/unit_test
-mv default.profraw unit_test.profraw
-llvm-profdata merge *.profraw -o profdata
-llvm-cov export -instr-profile profdata -format=lcov cmd/unit_test > silkrpc.lcov
+cd $PROJECT_DIR
+./build_clang_coverage.sh

--- a/rebuild_clang_debug.sh
+++ b/rebuild_clang_debug.sh
@@ -5,5 +5,5 @@ rm -fr build_clang_debug
 mkdir build_clang_debug
 cd build_clang_debug
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=$PROJECT_DIR/cmake/clang-libcxx20-fpic.cmake ..
-cmake --build . --parallel
-cmd/unit_test
+cd $PROJECT_DIR
+./build_clang_debug.sh

--- a/rebuild_clang_release.sh
+++ b/rebuild_clang_release.sh
@@ -5,5 +5,5 @@ rm -fr build_clang_release
 mkdir build_clang_release
 cd build_clang_release
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$PROJECT_DIR/cmake/clang-libcxx20-fpic.cmake ..
-cmake --build . --parallel
-cmd/unit_test
+cd $PROJECT_DIR
+./build_clang_release.sh

--- a/rebuild_gcc_debug.sh
+++ b/rebuild_gcc_debug.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+PROJECT_DIR=$PWD
 rm -fr build_gcc_debug
 mkdir build_gcc_debug
 cd build_gcc_debug
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 ..
-cmake --build . --parallel
-cmd/unit_test
+cd $PROJECT_DIR
+./build_gcc_debug.sh

--- a/rebuild_gcc_release.sh
+++ b/rebuild_gcc_release.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+PROJECT_DIR=$PWD
 rm -fr build_gcc_release
 mkdir build_gcc_release
 cd build_gcc_release
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 ..
-cmake --build . --parallel
-cmd/unit_test
+cd $PROJECT_DIR
+./build_gcc_release.sh


### PR DESCRIPTION
To fit compilation at the best with host resources the following modification have been made:
- removed `--parallel` option in all build/rebuild scripts
- reviewed scripts for code optimization
- added info on how enable parallel compilation using an env variable

Fixes #158 