### PR TITLE
Fix linter script to report execution errors

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -14,6 +14,7 @@ filter=-whitespace/comments
 
 # Disable one spaces requirement before class access modifier
 filter=-whitespace/indent
+filter=-whitespace/parens
 
 # Disable const requirement for argument references
 filter=-runtime/references

--- a/run_linter.sh
+++ b/run_linter.sh
@@ -5,4 +5,18 @@ cpplint \
     examples/*.cpp \
     silkrpc/*.hpp silkrpc/*.cpp silkrpc/**/*.hpp silkrpc/**/*.cpp silkrpc/**/**/*.hpp silkrpc/**/**/*.cpp
 
+if [ $? -ne 0 ];
+then
+    echo "cpplint failed"
+    exit 1
+fi
+
 pylint tests
+
+if [ $? -ne 0 ];
+then
+    echo "pylint failed"
+    exit 1
+fi
+
+exit 0

--- a/silkrpc/common/util.cpp
+++ b/silkrpc/common/util.cpp
@@ -139,7 +139,7 @@ bool check_tx_fee_less_cap(float cap, intx::uint256 max_fee_per_gas, uint64_t ga
         return true;
     }
 
-    float fee_eth = ((uint64_t)max_fee_per_gas * gas_limit) / (float)silkworm::kEther;
+    float fee_eth = (static_cast<uint64_t>(max_fee_per_gas) * gas_limit) / static_cast<float>(silkworm::kEther);
     if (fee_eth > cap) {
         return false;
     }

--- a/silkrpc/core/rawdb/chain.cpp
+++ b/silkrpc/core/rawdb/chain.cpp
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <iostream>
 #include <iomanip>
+#include <string>
 #include <utility>
 
 #include <boost/endian/conversion.hpp>

--- a/silkrpc/core/rawdb/chain_test.cpp
+++ b/silkrpc/core/rawdb/chain_test.cpp
@@ -137,8 +137,7 @@ void check_expected_transaction(const Transaction& transaction) {
     CHECK(transaction.block_base_fee_per_gas == std::nullopt);
     CHECK(transaction.chain_id == 5);
     CHECK(transaction.data == *silkworm::from_hex(
-        "f2f0387700000000000000000000000000000000000000000000000000000000000158b09f0270fc889c577c1c64db7c819f921d1b6e8c7e5d3f2ff34f162cf4b324cc05"
-    ));
+        "f2f0387700000000000000000000000000000000000000000000000000000000000158b09f0270fc889c577c1c64db7c819f921d1b6e8c7e5d3f2ff34f162cf4b324cc05"));
     CHECK(transaction.from == std::nullopt);
     //CHECK(transaction.nonce == 103470);
     CHECK(transaction.max_priority_fee_per_gas == 0x77359400);
@@ -147,7 +146,6 @@ void check_expected_transaction(const Transaction& transaction) {
     CHECK(transaction.gas_limit == 5000000);
     CHECK(transaction.transaction_index == 0);
     CHECK(transaction.type == Transaction::Type::kLegacy);
-    
 }
 
 TEST_CASE("read_header_number") {


### PR DESCRIPTION
Fix linter script to report execution errors
Add whitespace/parens filter
Fix linter errors