### PR TITLE
Fix intermittent unit test fail for Clang release

### DIFF
--- a/cmd/unit_test.cpp
+++ b/cmd/unit_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 The Silkrpc Authors
+   Copyright 2022 The Silkrpc Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmd/unit_test.cpp
+++ b/cmd/unit_test.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 The Silkworm Authors
+   Copyright 2021 The Silkrpc Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/silkrpc/commands/debug_api_test.cpp
+++ b/silkrpc/commands/debug_api_test.cpp
@@ -60,7 +60,7 @@ public:
         co_return;
     }
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek(silkworm::ByteView key) override {
         const auto key_ = silkworm::to_hex(key);
 
         KeyValue out;
@@ -81,7 +81,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override {
         const nlohmann::json table = json_.value(table_name_, empty);
         const auto& entry = table.value(silkworm::to_hex(key), "");
         auto value{*silkworm::from_hex(entry)};
@@ -103,7 +103,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 
@@ -114,7 +114,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 

--- a/silkrpc/core/account_dumper_test.cpp
+++ b/silkrpc/core/account_dumper_test.cpp
@@ -62,7 +62,7 @@ public:
         co_return;
     }
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek(silkworm::ByteView key) override {
         const auto key_ = silkworm::to_hex(key);
 
         KeyValue out;
@@ -83,7 +83,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override {
         const nlohmann::json table = json_.value(table_name_, empty);
         const auto& entry = table.value(silkworm::to_hex(key), "");
         auto value{*silkworm::from_hex(entry)};
@@ -105,7 +105,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 
@@ -116,7 +116,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 

--- a/silkrpc/core/account_walker_test.cpp
+++ b/silkrpc/core/account_walker_test.cpp
@@ -65,7 +65,7 @@ public:
         co_return;
     }
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek(silkworm::ByteView key) override {
         const auto key_ = silkworm::to_hex(key);
 
         KeyValue out;
@@ -86,7 +86,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override {
         const nlohmann::json table = json_.value(table_name_, empty);
         const auto& entry = table.value(silkworm::to_hex(key), "");
         auto value{*silkworm::from_hex(entry)};
@@ -108,7 +108,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 
@@ -119,7 +119,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 

--- a/silkrpc/core/blocks_test.cpp
+++ b/silkrpc/core/blocks_test.cpp
@@ -51,13 +51,13 @@ TEST_CASE("get_block_number", "[silkrpc][core][blocks]") {
     asio::thread_pool pool{1};
 
     SECTION("kEarliestBlockId") {
-        static const std::string EARLIEST_BLOCK_ID = kEarliestBlockId;
+        const std::string EARLIEST_BLOCK_ID = kEarliestBlockId;
         auto result = asio::co_spawn(pool, get_block_number(EARLIEST_BLOCK_ID, db_reader), asio::use_future);
         CHECK(result.get() == kEarliestBlockNumber);
     }
 
     SECTION("kLatestBlockId") {
-        static const std::string LATEST_BLOCK_ID = kLatestBlockId;
+        const std::string LATEST_BLOCK_ID = kLatestBlockId;
         EXPECT_CALL(db_reader, get(db::table::kSyncStageProgress, kExecutionStage)).WillOnce(InvokeWithoutArgs(
             []() -> asio::awaitable<KeyValue> { co_return KeyValue{silkworm::Bytes{}, *silkworm::from_hex("1234567890123456")}; }
         ));
@@ -66,7 +66,7 @@ TEST_CASE("get_block_number", "[silkrpc][core][blocks]") {
     }
 
     SECTION("kPendingBlockId") {
-        static const std::string PENDING_BLOCK_ID = kPendingBlockId;
+        const std::string PENDING_BLOCK_ID = kPendingBlockId;
         EXPECT_CALL(db_reader, get(db::table::kSyncStageProgress, kExecutionStage)).WillOnce(InvokeWithoutArgs(
             []() -> asio::awaitable<KeyValue> { co_return KeyValue{silkworm::Bytes{}, *silkworm::from_hex("1234567890123456")}; }
         ));
@@ -75,13 +75,13 @@ TEST_CASE("get_block_number", "[silkrpc][core][blocks]") {
     }
 
     SECTION("number in hex") {
-        static const std::string BLOCK_ID_HEX = "0x12345";
+        const std::string BLOCK_ID_HEX = "0x12345";
         auto result = asio::co_spawn(pool, get_block_number(BLOCK_ID_HEX, db_reader), asio::use_future);
         CHECK(result.get() == 0x12345);
     }
 
     SECTION("number in dec") {
-        static const std::string BLOCK_ID_DEC = "67890";
+        const std::string BLOCK_ID_DEC = "67890";
         auto result = asio::co_spawn(pool, get_block_number(BLOCK_ID_DEC, db_reader), asio::use_future);
         CHECK(result.get() == 67890);
     }

--- a/silkrpc/core/storage_walker_test.cpp
+++ b/silkrpc/core/storage_walker_test.cpp
@@ -63,7 +63,7 @@ public:
         co_return;
     }
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek(silkworm::ByteView key) override {
         const auto key_ = silkworm::to_hex(key);
 
         KeyValue out;
@@ -84,7 +84,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override {
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override {
         const nlohmann::json table = json_.value(table_name_, empty);
         const auto& entry = table.value(silkworm::to_hex(key), "");
         auto value{*silkworm::from_hex(entry)};
@@ -106,7 +106,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 
@@ -117,7 +117,7 @@ public:
         co_return out;
     }
 
-    asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) override {
+    asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override {
         silkworm::Bytes key_{key};
         key_ += value;
 

--- a/silkrpc/ethdb/cursor.hpp
+++ b/silkrpc/ethdb/cursor.hpp
@@ -40,9 +40,9 @@ public:
 
     virtual asio::awaitable<void> open_cursor(const std::string& table_name) = 0;
 
-    virtual asio::awaitable<KeyValue> seek(const silkworm::ByteView& key) = 0;
+    virtual asio::awaitable<KeyValue> seek(silkworm::ByteView key) = 0;
 
-    virtual asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) = 0;
+    virtual asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) = 0;
 
     virtual asio::awaitable<KeyValue> next() = 0;
 
@@ -51,9 +51,9 @@ public:
 
 class CursorDupSort : public Cursor {
 public:
-    virtual asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) = 0;
+    virtual asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) = 0;
 
-    virtual asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) = 0;
+    virtual asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) = 0;
 };
 
 struct SplittedKeyValue {

--- a/silkrpc/ethdb/cursor_test.cpp
+++ b/silkrpc/ethdb/cursor_test.cpp
@@ -54,7 +54,7 @@ public:
 
     asio::awaitable<void> open_cursor(const std::string& table_name) override { co_return; }
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& seek_key) override {
+    asio::awaitable<KeyValue> seek(silkworm::ByteView seek_key) override {
         index_ = 0;
         for (; index_ < vector_.size(); index_++) {
             if (vector_[index_].part1 == seek_key) {
@@ -65,7 +65,7 @@ public:
         co_return KeyValue{};
     }
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override { co_return KeyValue{silkworm::Bytes{key}, value}; }
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override { co_return KeyValue{silkworm::Bytes{key}, value}; }
 
     asio::awaitable<KeyValue> next() override {
         if (++index_ >= vector_.size()) {

--- a/silkrpc/ethdb/kv/remote_cursor.cpp
+++ b/silkrpc/ethdb/kv/remote_cursor.cpp
@@ -31,7 +31,7 @@ asio::awaitable<void> RemoteCursor::open_cursor(const std::string& table_name) {
     co_return;
 }
 
-asio::awaitable<KeyValue> RemoteCursor::seek(const silkworm::ByteView& key) {
+asio::awaitable<KeyValue> RemoteCursor::seek(silkworm::ByteView key) {
     const auto start_time = clock_time::now();
     SILKRPC_DEBUG << "RemoteCursor::seek cursor: " << cursor_id_ << " key: " << key << "\n";
     auto seek_pair = co_await kv_awaitable_.async_seek(cursor_id_, key, asio::use_awaitable);
@@ -41,7 +41,7 @@ asio::awaitable<KeyValue> RemoteCursor::seek(const silkworm::ByteView& key) {
     co_return KeyValue{k, v};
 }
 
-asio::awaitable<KeyValue> RemoteCursor::seek_exact(const silkworm::ByteView& key) {
+asio::awaitable<KeyValue> RemoteCursor::seek_exact(silkworm::ByteView key) {
     const auto start_time = clock_time::now();
     SILKRPC_DEBUG << "RemoteCursor::seek_exact cursor: " << cursor_id_ << " key: " << key << "\n";
     auto seek_pair = co_await kv_awaitable_.async_seek_exact(cursor_id_, key, asio::use_awaitable);
@@ -60,7 +60,7 @@ asio::awaitable<KeyValue> RemoteCursor::next() {
     co_return KeyValue{k, v};
 }
 
-asio::awaitable<silkworm::Bytes> RemoteCursor::seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) {
+asio::awaitable<silkworm::Bytes> RemoteCursor::seek_both(silkworm::ByteView key, silkworm::ByteView value) {
     const auto start_time = clock_time::now();
     SILKRPC_DEBUG << "RemoteCursor::seek_both cursor: " << cursor_id_ << " key: " << key << " subkey: " << value << "\n";
     auto seek_pair = co_await kv_awaitable_.async_seek_both(cursor_id_, key, value, asio::use_awaitable);
@@ -70,7 +70,7 @@ asio::awaitable<silkworm::Bytes> RemoteCursor::seek_both(const silkworm::ByteVie
     co_return v;
 }
 
-asio::awaitable<KeyValue> RemoteCursor::seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) {
+asio::awaitable<KeyValue> RemoteCursor::seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) {
     const auto start_time = clock_time::now();
     SILKRPC_DEBUG << "RemoteCursor::seek_both_exact cursor: " << cursor_id_ << " key: " << key << " subkey: " << value << "\n";
     auto seek_pair = co_await kv_awaitable_.async_seek_both_exact(cursor_id_, key, value, asio::use_awaitable);

--- a/silkrpc/ethdb/kv/remote_cursor.hpp
+++ b/silkrpc/ethdb/kv/remote_cursor.hpp
@@ -46,17 +46,17 @@ public:
 
     asio::awaitable<void> open_cursor(const std::string& table_name) override;
 
-    asio::awaitable<KeyValue> seek(const silkworm::ByteView& seek_key) override;
+    asio::awaitable<KeyValue> seek(silkworm::ByteView key) override;
 
-    asio::awaitable<KeyValue> seek_exact(const silkworm::ByteView& key) override;
+    asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override;
 
     asio::awaitable<KeyValue> next() override;
 
     asio::awaitable<void> close_cursor() override;
 
-    asio::awaitable<silkworm::Bytes> seek_both(const silkworm::ByteView& key, const silkworm::ByteView& value) override;
+    asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override;
 
-    asio::awaitable<KeyValue> seek_both_exact(const silkworm::ByteView& key, const silkworm::ByteView& value) override;
+    asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override;
 
 private:
     KvAsioAwaitable<asio::io_context::executor_type>& kv_awaitable_;

--- a/silkrpc/ethdb/kv/remote_cursor_test.cpp
+++ b/silkrpc/ethdb/kv/remote_cursor_test.cpp
@@ -43,9 +43,9 @@ public:
 
 TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient1 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient1(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     remote::Pair pair;
@@ -60,7 +60,7 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient1 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -74,9 +74,9 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("write_start failure") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient2 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient2(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     remote::Pair pair;
@@ -91,7 +91,7 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient2 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -105,9 +105,9 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("read_start failure") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient3 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient3(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     read_completed(grpc::Status::CANCELLED, {});
@@ -122,7 +122,7 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient3 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -138,9 +138,9 @@ TEST_CASE("RemoteCursor::open_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient4 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient4(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -153,7 +153,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient4 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -172,9 +172,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("success w/ async read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient5 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient5(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     remote::Pair pair;
@@ -189,7 +189,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient5 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -208,9 +208,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("success w/ sync read - async write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient6 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient6(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -225,7 +225,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient6 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -244,9 +244,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("success w/ async read - async write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient7 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient7(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     remote::Pair pair;
@@ -263,7 +263,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient7 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -282,9 +282,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("write_start failure") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient8 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient8(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     remote::Pair pair;
@@ -301,7 +301,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient8 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -321,9 +321,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
     }
 
     SECTION("read_start failure") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient9 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient9(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 auto result = std::async([&]() {
                     read_completed(grpc::Status::CANCELLED, {});
@@ -338,7 +338,7 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient9 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -360,9 +360,9 @@ TEST_CASE("RemoteCursor::close_cursor", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::seek", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient10 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient10(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -377,7 +377,7 @@ TEST_CASE("RemoteCursor::seek", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient10 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -404,9 +404,9 @@ TEST_CASE("RemoteCursor::seek", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::seek_exact", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient11 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient11(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -420,7 +420,7 @@ TEST_CASE("RemoteCursor::seek_exact", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient11 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -447,9 +447,9 @@ TEST_CASE("RemoteCursor::seek_exact", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::next", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient12 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient12(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -464,7 +464,7 @@ TEST_CASE("RemoteCursor::next", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient12 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -491,9 +491,9 @@ TEST_CASE("RemoteCursor::next", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::seek_both", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient13 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient13(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -507,7 +507,7 @@ TEST_CASE("RemoteCursor::seek_both", "[silkrpc][ethdb][kv][remote_cursor]") {
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient13 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {
@@ -533,9 +533,9 @@ TEST_CASE("RemoteCursor::seek_both", "[silkrpc][ethdb][kv][remote_cursor]") {
 
 TEST_CASE("RemoteCursor::seek_both_exact", "[silkrpc][ethdb][kv][remote_cursor]") {
     SECTION("success w/ sync read - sync write") {
-        class MockStreamingClient : public MockBaseStreamingClient {
+        class MockStreamingClient14 : public MockBaseStreamingClient {
         public:
-            MockStreamingClient(std::shared_ptr<grpc::Channel> /*channel*/, grpc::CompletionQueue* /*queue*/) {}
+            MockStreamingClient14(std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue) {}
             void read_start(std::function<void(const grpc::Status&, const remote::Pair&)> read_completed) override {
                 remote::Pair pair;
                 pair.set_cursorid(3);
@@ -549,7 +549,7 @@ TEST_CASE("RemoteCursor::seek_both_exact", "[silkrpc][ethdb][kv][remote_cursor]"
         asio::io_context io_context;
         auto channel = grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials());
         grpc::CompletionQueue queue;
-        MockStreamingClient client{channel, &queue};
+        MockStreamingClient14 client{channel, &queue};
         KvAsioAwaitable<asio::io_context::executor_type> kv_awaitable{io_context, client};
         RemoteCursor remote_cursor{kv_awaitable};
         try {

--- a/tests/unit/run_unit_test_loop.py
+++ b/tests/unit/run_unit_test_loop.py
@@ -2,12 +2,11 @@
 """ Stress the unit test suite on multiple compiler + build configurations
 """
 
+from enum import Enum
 import getopt
 import os
 import sys
-
-DEFAULT_TEST_NAME : str = None
-DEFAULT_NUM_ITERATIONS : int = 1000
+from typing import Dict, List
 
 SILKRPC_CLANG_COVERAGE_BUILDDIR : str = "../../build_clang_coverage/"
 SILKRPC_CLANG_DEBUG_BUILDDIR : str = "../../build_clang_debug/"
@@ -15,12 +14,19 @@ SILKRPC_CLANG_RELEASE_BUILDDIR : str = "../../build_clang_release/"
 SILKRPC_GCC_DEBUG_BUILDDIR : str = "../../build_gcc_debug/"
 SILKRPC_GCC_RELEASE_BUILDDIR : str = "../../build_gcc_release/"
 
+class Build(str, Enum):
+    CLANG_COVERAGE = 'CLANG_COVERAGE'
+    CLANG_DEBUG = 'CLANG_DEBUG'
+    CLANG_RELEASE = 'CLANG_RELEASE'
+    GCC_DEBUG = 'GCC_DEBUG'
+    GCC_RELEASE = 'GCC_RELEASE'
+
 class UnitTest:
     """ The unit test executable """
 
-    def __init__(self, name: str, build_dir: str):
+    def __init__(self, build_config: Build, build_dir: str):
         """ Create a new unit test execution """
-        self.name = name
+        self.build_config = build_config
         self.build_dir = build_dir
 
     def execute(self, num_iterations: int, test_name: str = None) -> None:
@@ -28,26 +34,45 @@ class UnitTest:
         cmd = self.build_dir + "cmd/unit_test"
         if test_name is not None:
             cmd = cmd + " \"" + test_name + "\""
-        print(cmd + "\n")
+        print("Unit test runner: " + cmd + "\n")
 
-        print("Unit test stress for " + self.name + " STARTED")
+        print("Unit test stress for " + self.build_config.name + " STARTED")
         for i in range(num_iterations):
             status = os.system(cmd)
             if status != 0:
-                print("Unit test stress for " + self.name + " FAILED [i=" + str(i) + "]")
+                print("Unit test stress for " + self.build_config.name + " FAILED [i=" + str(i) + "]")
                 sys.exit(-1)
-        print("Unit test stress for " + self.name + " COMPLETED [" + str(num_iterations) + "]")
+        print("Unit test stress for " + self.build_config.name + " COMPLETED [" + str(num_iterations) + "]")
 
+UNIT_TESTS_BY_BUILD : Dict[Build, UnitTest] = {
+    Build.CLANG_COVERAGE : UnitTest(Build.CLANG_COVERAGE, SILKRPC_CLANG_COVERAGE_BUILDDIR),
+    Build.CLANG_DEBUG : UnitTest(Build.CLANG_DEBUG, SILKRPC_CLANG_DEBUG_BUILDDIR),
+    Build.CLANG_RELEASE : UnitTest(Build.CLANG_RELEASE, SILKRPC_CLANG_RELEASE_BUILDDIR),
+    Build.GCC_DEBUG : UnitTest(Build.GCC_DEBUG, SILKRPC_GCC_DEBUG_BUILDDIR),
+    Build.GCC_RELEASE: UnitTest(Build.GCC_RELEASE, SILKRPC_GCC_RELEASE_BUILDDIR)
+}
+
+DEFAULT_TEST_NAME : str = None
+DEFAULT_NUM_ITERATIONS : int = 1000
+DEFAULT_BUILD_NAMES : List[str] = [
+    Build.CLANG_COVERAGE,
+    Build.CLANG_DEBUG,
+    Build.CLANG_RELEASE,
+    Build.GCC_DEBUG,
+    Build.GCC_RELEASE
+]
 
 def usage(argv):
     """ Print usage """
-    print("Usage: " + argv[0] + " [-h] [-i iterations] [-t test]")
+    print("Usage: " + argv[0] + " [-h] [-b builds] [-i iterations] [-t test]")
     print("")
     print("Launch an automated unit test sequence on all compiler/build configurations")
     print("")
     print("-h\tprint this help")
+    print("-b\tbuilds")
+    print("  \tthe list of build configurations separated by comma (default: " + ",".join(DEFAULT_BUILD_NAMES) + ")")
     print("-i\titerations")
-    print("  \tthe number of iterations to perform for each configuration (default: 1000)")
+    print("  \tthe number of iterations to perform for each configuration (default: " + str(DEFAULT_NUM_ITERATIONS) + ")")
     print("-t\ttest")
     print("  \tthe name of the unique TEST to execute (default: run all tests)")
     sys.exit(0)
@@ -56,31 +81,31 @@ def usage(argv):
 # main
 #
 def main(argv):
-    """ Main entry point
-    """
-    opts, _ = getopt.getopt(argv[1:], "hi:t:")
+    """ Main entry point """
+    opts, _ = getopt.getopt(argv[1:], "hb:i:t:")
 
     test_name = DEFAULT_TEST_NAME
     iterations = DEFAULT_NUM_ITERATIONS
+    build_names = DEFAULT_BUILD_NAMES
 
     for option, optarg in opts:
         if option in ("-h", "--help"):
             usage(argv)
+        elif option == "-b":
+            build_names = str(optarg).split(",")
         elif option == "-i":
             iterations = int(optarg)
         elif option == "-t":
             test_name = optarg
 
-    unit_tests = [
-        UnitTest("CLANG_COVERAGE", SILKRPC_CLANG_COVERAGE_BUILDDIR),
-        UnitTest("CLANG_DEBUG", SILKRPC_CLANG_DEBUG_BUILDDIR),
-        UnitTest("CLANG_RELEASE", SILKRPC_CLANG_RELEASE_BUILDDIR),
-        UnitTest("GCC_DEBUG", SILKRPC_GCC_DEBUG_BUILDDIR),
-        UnitTest("GCC_RELEASE", SILKRPC_GCC_RELEASE_BUILDDIR),
-    ]
-
-    for test in unit_tests:
-        test.execute(iterations, test_name)
+    for build_name in build_names:
+        build_name = build_name.upper()
+        if not build_name in Build._member_names_:
+            print("Invalid build name [" + build_name + "], ignored")
+            continue
+        build = Build[build_name]
+        unit_test = UNIT_TESTS_BY_BUILD[build]
+        unit_test.execute(iterations, test_name)
 
 
 #

--- a/tests/unit/run_unit_test_loop.py
+++ b/tests/unit/run_unit_test_loop.py
@@ -15,11 +15,17 @@ SILKRPC_GCC_DEBUG_BUILDDIR : str = "../../build_gcc_debug/"
 SILKRPC_GCC_RELEASE_BUILDDIR : str = "../../build_gcc_release/"
 
 class Build(str, Enum):
+    """ The build configuration """
     CLANG_COVERAGE = 'CLANG_COVERAGE'
     CLANG_DEBUG = 'CLANG_DEBUG'
     CLANG_RELEASE = 'CLANG_RELEASE'
     GCC_DEBUG = 'GCC_DEBUG'
     GCC_RELEASE = 'GCC_RELEASE'
+
+    @classmethod
+    def has_item(cls, name: str) -> bool:
+        """ Return true if name is a valid enumeration item, false otherwise """
+        return name in Build._member_names_ # pylint: disable=no-member
 
 class UnitTest:
     """ The unit test executable """
@@ -100,7 +106,7 @@ def main(argv):
 
     for build_name in build_names:
         build_name = build_name.upper()
-        if not build_name in Build._member_names_:
+        if not Build.has_item(build_name):
             print("Invalid build name [" + build_name + "], ignored")
             continue
         build = Build[build_name]


### PR DESCRIPTION
Remove pass-by-ref for silkworm::ByteView
Improve unit test loop runner
Fixes #186 