### PR TITLE
Evm_tracing changed in Evm_debug

### DIFF
--- a/silkrpc/core/evm_executor.cpp
+++ b/silkrpc/core/evm_executor.cpp
@@ -32,7 +32,7 @@
 
 #include <silkrpc/common/log.hpp>
 #include <silkrpc/common/util.hpp>
-#include <silkrpc/core/evm_tracing.hpp>
+// #include <silkrpc/core/evm_debug.hpp>
 
 namespace silkrpc {
 

--- a/silkrpc/core/evm_executor.cpp
+++ b/silkrpc/core/evm_executor.cpp
@@ -32,7 +32,6 @@
 
 #include <silkrpc/common/log.hpp>
 #include <silkrpc/common/util.hpp>
-// #include <silkrpc/core/evm_debug.hpp>
 
 namespace silkrpc {
 


### PR DESCRIPTION
The word `tracing` was not the best choice for the implementation of the tracer use in debug_* API calls as the word `debug `suits better. The refactoring changed several names for that reason.
This is preparatory for tracer to be used in trace_* API calls.