### PR TITLE
Refactor command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ We use the standard C++20 programming language. We follow the [Google's C++ Styl
 From the build folder (`build_[gcc, clang]_[debug, release]` according to your choice) you typically activate Silkrpc using:
 
 ```
-$ silkrpc/silkrpcdaemon --target <erigon_core_host_address>:9090
+$ silkrpc/silkrpcdaemon --target <core_service_host_address>:9090
 ```
 
-where `<erigon_core_host_address>` is the hostname or IP address of the Erigon Core to connect to.
+where `<core_service_host_address>` is the hostname or IP address of the Core services to connect to.
 
 You can check all command-line parameters supported by Silkrpc using:
 
@@ -153,11 +153,12 @@ silkrpcdaemon: C++ implementation of ETH JSON Remote Procedure Call (RPC) daemon
     --chaindata (chain data path as string); default: "";
     --http_port (Ethereum JSON RPC API local binding as string <address>:<port>); default: "localhost:8545";
     --engine_port (Engine JSON RPC API local binding as string <address>:<port>); default: "localhost:8550";
-    --logLevel (logging level); default: c;
-    --numContexts (number of running I/O contexts as 32-bit integer); default: number of hardware thread contexts / 2;
-    --numWorkers (number of worker threads as 32-bit integer); default: number of hardware thread contexts;
-    --target (Erigon Core gRPC service location as string <address>:<port>); default: "localhost:9090";
-    --timeout (gRPC call timeout as 32-bit integer); default: 10000;
+    --log_verbosity (logging verbosity level); default: c;
+    --num_contexts (number of running I/O contexts as integer); default: number of hardware thread contexts / 3;
+    --num_workers (number of worker threads as integer); default: 16;
+    --target (Core gRPC service location as string <address>:<port>); default: "localhost:9090";
+    --timeout (gRPC call timeout as integer); default: 10000;
+    --wait_mode (I/O scheduler wait mode); default: blocking;
 ```
 
 You can also check the Silkrpc executable version by:

--- a/cmd/silkrpc_toolbox.cpp
+++ b/cmd/silkrpc_toolbox.cpp
@@ -35,7 +35,7 @@ int kv_seek_both(const std::string& target, const std::string& table_name, const
 int kv_seek(const std::string& target, const std::string& table_name, const silkworm::Bytes& key);
 
 ABSL_FLAG(std::string, key, "", "key as hex string w/o leading 0x");
-ABSL_FLAG(silkrpc::LogLevel, logLevel, silkrpc::LogLevel::Critical, "logging level as string");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging level as string");
 ABSL_FLAG(std::string, seekkey, "", "seek key as hex string w/o leading 0x");
 ABSL_FLAG(std::string, subkey, "", "subkey as hex string w/o leading 0x");
 ABSL_FLAG(std::string, tool, "", "gRPC remote interface tool name as string");
@@ -253,7 +253,7 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_logLevel));
+    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_log_verbosity));
 
     const std::string tool{positional_args[1]};
     if (tool == "ethbackend_async") {

--- a/examples/get_latest_block.cpp
+++ b/examples/get_latest_block.cpp
@@ -43,7 +43,7 @@
 #include <silkrpc/ethdb/kv/remote_database.hpp>
 
 ABSL_FLAG(std::string, target, silkrpc::kDefaultTarget, "server location as string <address>:<port>");
-ABSL_FLAG(silkrpc::LogLevel, logLevel, silkrpc::LogLevel::Critical, "logging level");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging level");
 
 using silkrpc::LogLevel;
 
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
     absl::SetProgramUsageMessage("Seek Erigon/Silkworm Key-Value (KV) remote interface to database");
     absl::ParseCommandLine(argc, argv);
 
-    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_logLevel));
+    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_log_verbosity));
 
     try {
         auto target{absl::GetFlag(FLAGS_target)};

--- a/silkrpc/context_pool.cpp
+++ b/silkrpc/context_pool.cpp
@@ -32,6 +32,42 @@ std::ostream& operator<<(std::ostream& out, Context& c) {
     return out;
 }
 
+bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error) {
+    if (text == "blocking") {
+        *wait_mode = WaitMode::blocking;
+        return true;
+    }
+    if (text == "sleeping") {
+        *wait_mode = WaitMode::sleeping;
+        return true;
+    }
+    if (text == "yielding") {
+        *wait_mode = WaitMode::yielding;
+        return true;
+    }
+    if (text == "spin_wait") {
+        *wait_mode = WaitMode::spin_wait;
+        return true;
+    }
+    if (text == "busy_spin") {
+        *wait_mode = WaitMode::busy_spin;
+        return true;
+    }
+    *error = "unknown value for WaitMode";
+    return false;
+}
+
+std::string AbslUnparseFlag(WaitMode wait_mode) {
+    switch (wait_mode) {
+        case WaitMode::blocking: return "blocking";
+        case WaitMode::sleeping: return "sleeping";
+        case WaitMode::yielding: return "yielding";
+        case WaitMode::spin_wait: return "spin_wait";
+        case WaitMode::busy_spin: return "busy_spin";
+        default: return absl::StrCat(wait_mode);
+    }
+}
+
 std::unique_ptr<WaitStrategy> make_wait_strategy(WaitMode wait_mode) {
     switch (wait_mode) {
         case WaitMode::yielding:

--- a/silkrpc/context_pool.hpp
+++ b/silkrpc/context_pool.hpp
@@ -22,8 +22,10 @@
 #include <iostream>
 #include <list>
 #include <memory>
+#include <string>
 #include <vector>
 
+#include <absl/strings/string_view.h>
 #include <asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 
@@ -212,6 +214,9 @@ enum class WaitMode {
     spin_wait,
     busy_spin
 };
+
+bool AbslParseFlag(absl::string_view text, WaitMode* wait_mode, std::string* error);
+std::string AbslUnparseFlag(WaitMode wait_mode);
 
 std::unique_ptr<WaitStrategy> make_wait_strategy(WaitMode wait_mode);
 

--- a/silkrpc/context_pool_test.cpp
+++ b/silkrpc/context_pool_test.cpp
@@ -169,6 +169,52 @@ namespace silkrpc {
 
 using Catch::Matchers::Message;
 
+TEST_CASE("parse wait mode", "[silkrpc][common][log]") {
+    std::vector<absl::string_view> input_texts{
+        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+    };
+    std::vector<WaitMode> expected_wait_modes{
+        WaitMode::blocking,
+        WaitMode::sleeping,
+        WaitMode::yielding,
+        WaitMode::spin_wait,
+        WaitMode::busy_spin,
+    };
+    for (auto i{0}; i < input_texts.size(); i++) {
+        WaitMode wait_mode;
+        std::string error;
+        const auto success{AbslParseFlag(input_texts[i], &wait_mode, &error)};
+        CHECK(success == true);
+        CHECK(error.empty());
+        CHECK(wait_mode == expected_wait_modes[i]);
+    }
+}
+
+TEST_CASE("parse invalid wait mode", "[silkrpc][common][log]") {
+    WaitMode wait_mode;
+    std::string error;
+    const auto success{AbslParseFlag("abc", &wait_mode, &error)};
+    CHECK(success == false);
+    CHECK(!error.empty());
+}
+
+TEST_CASE("unparse wait mode", "[silkrpc][common][log]") {
+    std::vector<WaitMode> input_wait_modes{
+        WaitMode::blocking,
+        WaitMode::sleeping,
+        WaitMode::yielding,
+        WaitMode::spin_wait,
+        WaitMode::busy_spin,
+    };
+    std::vector<absl::string_view> expected_texts{
+        "blocking", "sleeping", "yielding", "spin_wait", "busy_spin"
+    };
+    for (auto i{0}; i < input_wait_modes.size(); i++) {
+        const auto text{AbslUnparseFlag(input_wait_modes[i])};
+        CHECK(text == expected_texts[i]);
+    }
+}
+
 template<typename R, typename P>
 inline void sleep_then_check_wait(WaitStrategy& w, const std::chrono::duration<R, P>& t, uint32_t executed_count) {
     std::this_thread::sleep_for(t);

--- a/silkrpc/main.cpp
+++ b/silkrpc/main.cpp
@@ -50,10 +50,11 @@ ABSL_FLAG(std::string, http_port, silkrpc::kDefaultHttpPort, "Ethereum JSON RPC 
 ABSL_FLAG(std::string, engine_port, silkrpc::kDefaultEnginePort, "Engine JSON RPC API local end-point as string <address>:<port>");
 ABSL_FLAG(std::string, target, silkrpc::kDefaultTarget, "Erigon Core gRPC service location as string <address>:<port>");
 ABSL_FLAG(std::string, api_spec, silkrpc::kDefaultEth1ApiSpec, "JSON RPC API namespaces as comma-separated list of strings");
-ABSL_FLAG(uint32_t, numContexts, std::thread::hardware_concurrency() / 2, "number of running I/O contexts as 32-bit integer");
-ABSL_FLAG(uint32_t, numWorkers, 16, "number of worker threads as 32-bit integer");
+ABSL_FLAG(uint32_t, num_contexts, std::thread::hardware_concurrency() / 3, "number of running I/O contexts as 32-bit integer");
+ABSL_FLAG(uint32_t, num_workers, 16, "number of worker threads as 32-bit integer");
 ABSL_FLAG(uint32_t, timeout, silkrpc::kDefaultTimeout.count(), "gRPC call timeout as 32-bit integer");
-ABSL_FLAG(silkrpc::LogLevel, logLevel, silkrpc::LogLevel::Critical, "logging level");
+ABSL_FLAG(silkrpc::LogLevel, log_verbosity, silkrpc::LogLevel::Critical, "logging verbosity level");
+ABSL_FLAG(silkrpc::WaitMode, wait_mode, silkrpc::WaitMode::blocking, "scheduler wait mode");
 
 //! Assemble the application name using the Cable build information
 std::string get_name_from_build_info() {
@@ -106,7 +107,7 @@ int main(int argc, char* argv[]) {
     absl::SetProgramUsageMessage("C++ implementation of Ethereum JSON RPC API service within Thorax architecture");
     absl::ParseCommandLine(argc, argv);
 
-    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_logLevel));
+    SILKRPC_LOG_VERBOSITY(absl::GetFlag(FLAGS_log_verbosity));
     SILKRPC_LOG_THREAD(true);
 
     std::set_terminate([]() {
@@ -175,24 +176,26 @@ int main(int argc, char* argv[]) {
             return -1;
         }
 
-        auto numContexts{absl::GetFlag(FLAGS_numContexts)};
-        if (numContexts < 0) {
-            SILKRPC_ERROR << "Parameter numContexts is invalid: [" << numContexts << "]\n";
-            SILKRPC_ERROR << "Use --numContexts flag to specify the number of threads running I/O contexts\n";
+        auto num_contexts{absl::GetFlag(FLAGS_num_contexts)};
+        if (num_contexts < 0) {
+            SILKRPC_ERROR << "Parameter num_contexts is invalid: [" << num_contexts << "]\n";
+            SILKRPC_ERROR << "Use --num_contexts flag to specify the number of threads running I/O contexts\n";
             return -1;
         }
 
-        auto numWorkers{absl::GetFlag(FLAGS_numWorkers)};
-        if (numWorkers < 0) {
-            SILKRPC_ERROR << "Parameter numWorkers is invalid: [" << numWorkers << "]\n";
-            SILKRPC_ERROR << "Use --numWorkers flag to specify the number of worker threads executing long-run operations\n";
+        auto num_workers{absl::GetFlag(FLAGS_num_workers)};
+        if (num_workers < 0) {
+            SILKRPC_ERROR << "Parameter num_workers is invalid: [" << num_workers << "]\n";
+            SILKRPC_ERROR << "Use --num_workers flag to specify the number of worker threads executing long-run operations\n";
             return -1;
         }
+
+        const auto wait_mode{absl::GetFlag(FLAGS_wait_mode)};
 
         if (chaindata.empty()) {
-            SILKRPC_LOG << "Silkrpc launched with target " << target << " using " << numContexts << " contexts, " << numWorkers << " workers\n";
+            SILKRPC_LOG << "Silkrpc launched with target " << target << " using " << num_contexts << " contexts, " << num_workers << " workers\n";
         } else {
-            SILKRPC_LOG << "Silkrpc launched with chaindata " << chaindata << " using " << numContexts << " contexts, " << numWorkers << " workers\n";
+            SILKRPC_LOG << "Silkrpc launched with chaindata " << chaindata << " using " << num_contexts << " contexts, " << num_workers << " workers\n";
         }
 
         // TODO(canepat): handle also secure channel for remote
@@ -226,8 +229,8 @@ int main(int argc, char* argv[]) {
         SILKRPC_LOG << txpool_protocol_check.result << "\n";
 
         // TODO(canepat): handle also local (shared-memory) database
-        silkrpc::ContextPool context_pool{numContexts, create_channel};
-        asio::thread_pool worker_pool{numWorkers};
+        silkrpc::ContextPool context_pool{num_contexts, create_channel, wait_mode};
+        asio::thread_pool worker_pool{num_workers};
 
         silkrpc::http::Server eth_rpc_service{http_port, api_spec, context_pool, worker_pool};
         silkrpc::http::Server engine_rpc_service{engine_port, kDefaultEth2ApiSpec, context_pool, worker_pool};

--- a/tests/perf/run_perf_tests.py
+++ b/tests/perf/run_perf_tests.py
@@ -264,10 +264,10 @@ class PerfTest:
         else:
             perf_cmd = ""
         if on_core[0] == "-":
-            cmd = perf_cmd + self.config.silkrpc_build_dir + "silkrpc/silkrpcdaemon --target " + self.config.erigon_addr + " --http_port localhost:51515 --logLevel c --numWorkers 16 &"
+            cmd = perf_cmd + self.config.silkrpc_build_dir + "silkrpc/silkrpcdaemon --target " + self.config.erigon_addr + " --http_port localhost:51515 --log_verbosity c --num_workers 16 &"
         else:
             cmd = perf_cmd + "taskset -c " + on_core[0] + " "\
-                + self.config.silkrpc_build_dir + "silkrpc/silkrpcdaemon --target " + self.config.erigon_addr + " --http_port localhost:51515 --logLevel c  --numWorkers 16 --numContexts "\
+                + self.config.silkrpc_build_dir + "silkrpc/silkrpcdaemon --target " + self.config.erigon_addr + " --http_port localhost:51515 --log_verbosity c  --num_workers 16 --num_contexts "\
                     + str(self.config.silkrpc_num_contexts) + " &"
         print("SilkDaemon starting ...: ", cmd)
         status = os.system(cmd)


### PR DESCRIPTION
Rationale:
- renaming some options to make naming uniform and similar to Silkworm commands
- adding `wait_mode` option to change I/O scheduler wait mode