### PR TITLE
Change computed gasCost for opCode CALL

### DIFF
--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -291,6 +291,7 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(cons
 template<typename WorldState, typename VM>
 asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std::uint64_t block_number, const silkworm::Block& block,
         const silkrpc::Transaction& transaction, std::int32_t index) {
+
     SILKRPC_INFO << "DebugExecutor::execute: "
         << " block_number: " << block_number
         << " transaction: {" << transaction << "}"
@@ -301,6 +302,7 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std:
     const auto chain_id = co_await core::rawdb::read_chain_id(database_reader_);
     const auto chain_config_ptr = silkworm::lookup_chain_config(chain_id);
     EVMExecutor<WorldState, VM> executor{io_context_, database_reader_, *chain_config_ptr, workers_, block_number};
+
     for (auto idx = 0; idx < index; idx++) {
         silkrpc::Transaction txn{block.transactions[idx]};
 
@@ -310,6 +312,7 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std:
         const auto execution_result = co_await executor.call(block, txn);
     }
     executor.reset();
+
     DebugExecutorResult result;
     auto& debug_trace = result.debug_trace;
 

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -136,7 +136,6 @@ void DebugTracer::on_execution_start(evmc_revision rev, const evmc_message& msg,
 
 void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_top, const int stack_height,
               const evmone::ExecutionState& execution_state, const silkworm::IntraBlockState& intra_block_state) noexcept {
-
     assert(execution_state.msg);
     evmc::address recipient(execution_state.msg->recipient);
     evmc::address sender(execution_state.msg->sender);

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -136,6 +136,7 @@ void DebugTracer::on_execution_start(evmc_revision rev, const evmc_message& msg,
 
 void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_top, const int stack_height,
               const evmone::ExecutionState& execution_state, const silkworm::IntraBlockState& intra_block_state) noexcept {
+
     assert(execution_state.msg);
     evmc::address recipient(execution_state.msg->recipient);
     evmc::address sender(execution_state.msg->sender);
@@ -155,7 +156,6 @@ void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_
         << "   msg.gas: " << std::dec << execution_state.msg->gas
         << "   msg.depth: " << std::dec << execution_state.msg->depth
         << "}\n";
-
 
     bool output_storage = false;
     if (!config_.disableStorage) {
@@ -191,7 +191,7 @@ void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_
                 }
             }
         } else if (depth == execution_state.msg->depth) {
-            log.gas_cost = start_gas_;
+            log.gas_cost = log.gas - execution_state.gas_left;
         }
     }
 

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -122,7 +122,6 @@ void DebugTracer::on_execution_start(evmc_revision rev, const evmc_message& msg,
     if (opcode_names_ == nullptr) {
         opcode_names_ = evmc_get_instruction_names_table(rev);
     }
-
     start_gas_ = msg.gas;
     evmc::address recipient(msg.recipient);
     evmc::address sender(msg.sender);
@@ -180,9 +179,7 @@ void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_
         auto& log = logs_[logs_.size() - 1];
         auto depth = log.depth;
         if (depth == execution_state.msg->depth + 1) {
-            auto gas_cost = log.gas - execution_state.gas_left;
-            log.gas_cost = gas_cost;
-
+            log.gas_cost = log.gas - execution_state.gas_left;
             if (!config_.disableMemory) {
                 auto& memory = log.memory;
                 for (int idx = memory.size(); idx < current_memory.size(); idx++) {
@@ -193,7 +190,6 @@ void DebugTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stack_
             log.gas_cost = log.gas - execution_state.gas_left;
         }
     }
-
     DebugLog log;
     log.pc = pc;
     log.op = opcode_name == "KECCAK256" ? "SHA3" : opcode_name; // TODO(sixtysixter) for RPCDAEMON compatibility
@@ -282,7 +278,6 @@ asio::awaitable<std::vector<DebugTrace>> DebugExecutor<WorldState, VM>::execute(
             debug_trace.return_value = silkworm::to_hex(execution_result.data);
         }
     }
-
     co_return debug_traces;
 }
 
@@ -304,11 +299,8 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std:
         << "\n";
 
     const auto chain_id = co_await core::rawdb::read_chain_id(database_reader_);
-
     const auto chain_config_ptr = silkworm::lookup_chain_config(chain_id);
-
     EVMExecutor<WorldState, VM> executor{io_context_, database_reader_, *chain_config_ptr, workers_, block_number};
-
     for (auto idx = 0; idx < index; idx++) {
         silkrpc::Transaction txn{block.transactions[idx]};
 
@@ -317,9 +309,7 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std:
         }
         const auto execution_result = co_await executor.call(block, txn);
     }
-
     executor.reset();
-
     DebugExecutorResult result;
     auto& debug_trace = result.debug_trace;
 

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -291,13 +291,11 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(cons
 template<typename WorldState, typename VM>
 asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std::uint64_t block_number, const silkworm::Block& block,
         const silkrpc::Transaction& transaction, std::int32_t index) {
-
     SILKRPC_INFO << "DebugExecutor::execute: "
         << " block_number: " << block_number
         << " transaction: {" << transaction << "}"
         << " index: " << std::dec << index
-        << " config: " << config_
-        << "\n";
+        << " config: " << config_ << "\n";
 
     const auto chain_id = co_await core::rawdb::read_chain_id(database_reader_);
     const auto chain_config_ptr = silkworm::lookup_chain_config(chain_id);

--- a/silkrpc/core/evm_debug.cpp
+++ b/silkrpc/core/evm_debug.cpp
@@ -295,7 +295,8 @@ asio::awaitable<DebugExecutorResult> DebugExecutor<WorldState, VM>::execute(std:
         << " block_number: " << block_number
         << " transaction: {" << transaction << "}"
         << " index: " << std::dec << index
-        << " config: " << config_ << "\n";
+        << " config: " << config_
+        << "\n";
 
     const auto chain_id = co_await core::rawdb::read_chain_id(database_reader_);
     const auto chain_config_ptr = silkworm::lookup_chain_config(chain_id);

--- a/silkrpc/core/evm_executor_test.cpp
+++ b/silkrpc/core/evm_executor_test.cpp
@@ -635,6 +635,30 @@ TEST_CASE("EVMexecutor") {
         CHECK(error_message == "static mode violation");
     }
 
+    SECTION("get_error_message(EVMC_PRECOMPILE_FAILURE) with short error") {
+        StubDatabase tx_database;
+        const uint64_t chain_id = 5;
+        const auto chain_config_ptr = silkworm::lookup_chain_config(chain_id);
+
+        ChannelFactory my_channel = []() { return grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials()); };
+        ContextPool my_pool{1, my_channel};
+        asio::thread_pool workers{1};
+        auto pool_thread = std::thread([&]() { my_pool.run(); });
+
+        const auto block_number = 6000000;
+        silkworm::Block block{};
+        block.header.number = block_number;
+        silkworm::Transaction txn{};
+        txn.gas_limit = 60000;
+        txn.from = 0xa872626373628737383927236382161739290870_address;
+
+        EVMExecutor executor{my_pool.next_io_context(), tx_database, *chain_config_ptr, workers, block_number};
+        auto error_message = executor.get_error_message(evmc_status_code::EVMC_PRECOMPILE_FAILURE, error_data, false);
+        my_pool.stop();
+        pool_thread.join();
+        CHECK(error_message == "precompile failure");
+    }
+
     SECTION("get_error_message(wrong status_code) with short error") {
         StubDatabase tx_database;
         const uint64_t chain_id = 5;


### PR DESCRIPTION
Modified the silk code to calculate the gasCost of the opCode CALL in an equivalent way to the other opCodes.
When the correct behaviour will be found eventually we will modify again the SW.
The current calculation made by erigon is not possibile in silk without changes in evmone/silkworm .