### PR TITLE
asio-grpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ include(silkworm/third_party/evmone/cmake/cable/bootstrap.cmake)
 include(CableBuildInfo)
 include(silkworm/third_party/evmone/cmake/cable/HunterGate.cmake)
 HunterGate(
-  URL "https://github.com/cpp-pm/hunter/archive/v0.24.1.tar.gz"
-  SHA1 "4942227a6e6f5e64414c55b97ef98609de199d18"
+  URL "https://github.com/cpp-pm/hunter/archive/v0.24.3.tar.gz"
+  SHA1 "10738b59e539818a01090e64c2d09896247530c7"
   FILEPATH "${CMAKE_SOURCE_DIR}/cmake/Hunter/config.cmake"
 )
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -16,3 +16,10 @@
 
 # silkworm configuration
 include(${CMAKE_SOURCE_DIR}/silkworm/cmake/Hunter/config.cmake)
+
+hunter_config(
+    asio-grpc
+    VERSION ${HUNTER_asio-grpc_VERSION}
+    CMAKE_ARGS
+      ASIO_GRPC_USE_BOOST_CONTAINER=ON
+)

--- a/cmake/Hunter/packages.cmake
+++ b/cmake/Hunter/packages.cmake
@@ -15,7 +15,6 @@
 ]]
 
 hunter_add_package(abseil)
-hunter_add_package(asio)
 hunter_add_package(Catch)
 hunter_add_package(ethash)
 hunter_add_package(gRPC)
@@ -23,3 +22,4 @@ hunter_add_package(GTest)
 hunter_add_package(intx)
 hunter_add_package(nlohmann_json)
 hunter_add_package(Protobuf)
+hunter_add_package(asio-grpc)

--- a/cmd/ethbackend_coroutines.cpp
+++ b/cmd/ethbackend_coroutines.cpp
@@ -63,7 +63,7 @@ int ethbackend_coroutines(const std::string& target) {
         silkrpc::ContextPool context_pool{1, create_channel};
         auto& context = context_pool.next_context();
         auto io_context = context.io_context();
-        auto grpc_queue = context.grpc_queue();
+        auto grpc_context = context.grpc_context();
 
         boost::asio::signal_set signals(*io_context, SIGINT, SIGTERM);
         signals.async_wait([&](const boost::system::error_code& error, int signal_number) {
@@ -74,7 +74,7 @@ int ethbackend_coroutines(const std::string& target) {
         const auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
 
         // Etherbase
-        silkrpc::ethbackend::BackEndGrpc eth_backend{*io_context, channel, grpc_queue};
+        silkrpc::ethbackend::BackEndGrpc eth_backend{*io_context, channel, *grpc_context};
         boost::asio::co_spawn(*io_context, ethbackend_etherbase(eth_backend), [&](std::exception_ptr exptr) {
             context_pool.stop();
         });

--- a/cmd/unit_test.cpp
+++ b/cmd/unit_test.cpp
@@ -14,5 +14,37 @@
    limitations under the License.
 */
 
-#define CATCH_CONFIG_MAIN
+#include <gmock/gmock.h>
+
+#include <string>
+
+#define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleMock(&argc, argv);
+
+    auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    delete listeners.Release(listeners.default_result_printer());
+
+    class CatchListener : public ::testing::EmptyTestEventListener {
+      public:
+        virtual void OnTestPartResult(const ::testing::TestPartResult& result) override {
+            if (!result.failed()) {
+                return;
+            }
+            const auto file = result.file_name() ? result.file_name() : "unknown";
+            const auto line = result.line_number() != -1 ? result.line_number() : 0;
+            const auto message = result.message() ? result.message() : "no message";
+            ::Catch::SourceLineInfo source_line_info(file, static_cast<std::size_t>(line));
+            auto result_disposition = result.fatally_failed() ? ::Catch::ResultDisposition::Normal
+                                                              : ::Catch::ResultDisposition::ContinueOnFailure;
+            ::Catch::AssertionHandler assertion("GTEST", source_line_info, "", result_disposition);
+            assertion.handleMessage(::Catch::ResultWas::ExplicitFailure, result.message());
+            assertion.setCompleted();
+        }
+    };
+    listeners.Append(new CatchListener);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/silkrpc/CMakeLists.txt
+++ b/silkrpc/CMakeLists.txt
@@ -20,11 +20,9 @@ find_package(intx CONFIG REQUIRED)
 # Find Protobuf installation
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(Protobuf CONFIG REQUIRED)
-find_program(PROTOBUF_PROTOC protoc REQUIRED)
 
-# Find gRPC installation
-find_package(gRPC CONFIG REQUIRED)
-find_program(GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+# Find asio-grpc installation
+find_package(asio-grpc CONFIG REQUIRED)
 find_package(mimalloc 2.0 REQUIRED)
 
 # Define gRPC proto files
@@ -32,69 +30,49 @@ set(IF_PROTO_PATH "${CMAKE_SOURCE_DIR}/interfaces")
 
 # Generate Protocol Buffers and gRPC bindings
 set(PROTO_GENERATED_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/proto-bindings)
-file(MAKE_DIRECTORY ${PROTO_GENERATED_SRC_DIR})
 
-set(BACKEND_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/remote/ethbackend.pb.cc")
 set(BACKEND_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/ethbackend.pb.h")
-set(BACKEND_GRPC_SOURCE "${PROTO_GENERATED_SRC_DIR}/remote/ethbackend.grpc.pb.cc")
 set(BACKEND_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/ethbackend.grpc.pb.h")
 set(BACKEND_MOCK_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/ethbackend_mock.grpc.pb.h")
-set(KV_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/remote/kv.pb.cc")
 set(KV_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/kv.pb.h")
-set(KV_GRPC_SOURCE "${PROTO_GENERATED_SRC_DIR}/remote/kv.grpc.pb.cc")
 set(KV_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/kv.grpc.pb.h")
 set(KV_MOCK_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/remote/kv_mock.grpc.pb.h")
-set(P2PSENTRY_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/p2psentry/sentry.pb.cc")
 set(P2PSENTRY_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/p2psentry/sentry.pb.h")
-set(P2PSENTRY_GRPC_SOURCE "${PROTO_GENERATED_SRC_DIR}/p2psentry/sentry.grpc.pb.cc")
 set(P2PSENTRY_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/p2psentry/sentry.grpc.pb.h")
 set(P2PSENTRY_MOCK_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/p2psentry/sentry_mock.grpc.pb.h")
-set(MINING_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/txpool/mining.pb.cc")
 set(MINING_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/mining.pb.h")
-set(MINING_GRPC_SOURCE "${PROTO_GENERATED_SRC_DIR}/txpool/mining.grpc.pb.cc")
 set(MINING_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/mining.grpc.pb.h")
 set(MINING_MOCK_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/mining_mock.grpc.pb.h")
-set(TXPOOL_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/txpool/txpool.pb.cc")
 set(TXPOOL_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/txpool.pb.h")
-set(TXPOOL_GRPC_SOURCE "${PROTO_GENERATED_SRC_DIR}/txpool/txpool.grpc.pb.cc")
 set(TXPOOL_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/txpool.grpc.pb.h")
 set(TXPOOL_MOCK_GRPC_HEADER "${PROTO_GENERATED_SRC_DIR}/txpool/txpool_mock.grpc.pb.h")
-set(TYPES_PROTO_SOURCE "${PROTO_GENERATED_SRC_DIR}/types/types.pb.cc")
 set(TYPES_PROTO_HEADER "${PROTO_GENERATED_SRC_DIR}/types/types.pb.h")
 
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
 
-add_custom_command(
-    OUTPUT "${TYPES_PROTO_HEADER}" "${TYPES_PROTO_SOURCE}"
-      "${BACKEND_PROTO_HEADER}" "${BACKEND_PROTO_SOURCE}" "${BACKEND_GRPC_HEADER}" "${BACKEND_GRPC_SOURCE}"
-      "${KV_PROTO_SOURCE}" "${KV_PROTO_HEADER}" "${KV_GRPC_SOURCE}" "${KV_GRPC_HEADER}"
-      "${P2PSENTRY_PROTO_SOURCE}" "${P2PSENTRY_PROTO_HEADER}" "${P2PSENTRY_GRPC_SOURCE}" "${P2PSENTRY_GRPC_HEADER}"
-      "${MINING_PROTO_SOURCE}" "${MINING_PROTO_HEADER}" "${MINING_GRPC_SOURCE}" "${MINING_GRPC_HEADER}"
-      "${TXPOOL_PROTO_SOURCE}" "${TXPOOL_PROTO_HEADER}" "${TXPOOL_GRPC_SOURCE}" "${TXPOOL_GRPC_HEADER}"
-    COMMAND ${PROTOBUF_PROTOC}
-    ARGS --grpc_out generate_mock_code=true:"${PROTO_GENERATED_SRC_DIR}"
-      --cpp_out "${PROTO_GENERATED_SRC_DIR}"
-      --proto_path "${IF_PROTO_PATH}"
-      --plugin=protoc-gen-grpc="${GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "${IF_PROTO_PATH}/**/ethbackend.proto"
-      "${IF_PROTO_PATH}/**/kv.proto"
-      "${IF_PROTO_PATH}/**/sentry.proto"
-      "${IF_PROTO_PATH}/**/mining.proto"
-      "${IF_PROTO_PATH}/**/txpool.proto"
-      "${IF_PROTO_PATH}/**/types.proto"
-    COMMENT "Running C++ gRPC compiler on ${IF_PROTO_PATH}"
+# Silkinterfaces library
+add_library(silkinterfaces)
+
+asio_grpc_protobuf_generate(
+    GENERATE_GRPC GENERATE_MOCK_CODE
+    TARGET 
+    silkinterfaces
+    USAGE_REQUIREMENT
+    PUBLIC
+    OUT_DIR 
+    "${PROTO_GENERATED_SRC_DIR}"
+    IMPORT_DIRS
+    "${IF_PROTO_PATH}"
+    PROTOS
+    "${IF_PROTO_PATH}/remote/ethbackend.proto"
+    "${IF_PROTO_PATH}/remote/kv.proto"
+    "${IF_PROTO_PATH}/p2psentry/sentry.proto"
+    "${IF_PROTO_PATH}/txpool/mining.proto"
+    "${IF_PROTO_PATH}/txpool/txpool.proto"
+    "${IF_PROTO_PATH}/types/types.proto"
 )
 
-# Silkinterfaces library
-add_library(silkinterfaces
-    ${TYPES_PROTO_HEADER} ${TYPES_PROTO_SOURCE}
-    ${BACKEND_PROTO_HEADER} ${BACKEND_PROTO_SOURCE} ${BACKEND_GRPC_HEADER} ${BACKEND_GRPC_SOURCE}
-    ${KV_PROTO_HEADER} ${KV_PROTO_SOURCE} ${KV_GRPC_HEADER} ${KV_GRPC_SOURCE}
-    ${P2PSENTRY_PROTO_HEADER} ${P2PSENTRY_PROTO_SOURCE} ${P2PSENTRY_GRPC_HEADER} ${P2PSENTRY_GRPC_SOURCE}
-    ${MINING_PROTO_HEADER} ${MINING_PROTO_SOURCE} ${MINING_GRPC_HEADER} ${MINING_GRPC_SOURCE}
-    ${TXPOOL_PROTO_HEADER} ${TXPOOL_PROTO_SOURCE} ${TXPOOL_GRPC_HEADER} ${TXPOOL_GRPC_SOURCE})
-target_include_directories(silkinterfaces PUBLIC ${PROTO_GENERATED_SRC_DIR})
-target_link_libraries(silkinterfaces
+target_link_libraries(silkinterfaces PUBLIC
     gRPC::grpc++
     protobuf::libprotobuf)
 
@@ -158,27 +136,25 @@ add_custom_command(
 file(GLOB_RECURSE SILKRPC_SRC CONFIGURE_DEPENDS "*.cpp" "*.cc" "*.hpp" "*.c" "*.h")
 list(FILTER SILKRPC_SRC EXCLUDE REGEX "main\.cpp$|_test\.cpp$|\.pb\.cc|\.pb\.h")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -fcoroutines")
-endif()
-
 add_library(silkrpc ${SILKRPC_SRC})
 target_include_directories(silkrpc PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(silkrpc
+target_link_libraries(silkrpc PUBLIC
     absl::flat_hash_map
     absl::flat_hash_set
     absl::btree
     intx::intx
-    gRPC::grpc++
     protobuf::libprotobuf
     silkinterfaces
     silkworm_core
     silkworm_node
-    mimalloc)
+    mimalloc
+    asio-grpc::asio-grpc)
+target_compile_features(silkrpc PUBLIC cxx_std_20)
+target_compile_options(silkrpc PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:-fcoroutines>)
 
 add_executable(silkrpcdaemon main.cpp)
 target_include_directories(silkrpcdaemon PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(silkrpcdaemon
+target_link_libraries(silkrpcdaemon PRIVATE
     silkrpc
     absl::flags_parse
     silkinterfaces

--- a/silkrpc/commands/net_api_test.cpp
+++ b/silkrpc/commands/net_api_test.cpp
@@ -28,9 +28,9 @@ using Catch::Matchers::Message;
 TEST_CASE("NetRpcApi::NetRpcApi", "[silkrpc][erigon_api]") {
     boost::asio::io_context io_context;
     auto channel{grpc::CreateChannel("localhost", grpc::InsecureChannelCredentials())};
-    grpc::CompletionQueue queue;
+    agrpc::GrpcContext grpc_context{std::make_unique<grpc::CompletionQueue>()};
     std::unique_ptr<ethbackend::BackEnd> backend{
-        std::make_unique<ethbackend::BackEndGrpc>(io_context, channel, &queue)
+        std::make_unique<ethbackend::BackEndGrpc>(io_context, channel, grpc_context)
     };
     CHECK_NOTHROW(NetRpcApi{backend});
 }

--- a/silkrpc/context_pool.cpp
+++ b/silkrpc/context_pool.cpp
@@ -20,8 +20,8 @@
 #include <thread>
 #include <utility>
 
-#include <agrpc/grpcExecutor.hpp>
-#include <agrpc/grpcContext.hpp>
+#include <agrpc/grpc_executor.hpp>
+#include <agrpc/grpc_context.hpp>
 #include <agrpc/run.hpp>
 
 #include <silkrpc/common/log.hpp>

--- a/silkrpc/context_pool.hpp
+++ b/silkrpc/context_pool.hpp
@@ -26,7 +26,7 @@
 #include <thread>
 #include <utility>
 
-#include <agrpc/grpcContext.hpp>
+#include <agrpc/grpc_context.hpp>
 #include <boost/asio/io_context.hpp>
 #include <grpcpp/grpcpp.h>
 

--- a/silkrpc/context_pool_test.cpp
+++ b/silkrpc/context_pool_test.cpp
@@ -26,8 +26,6 @@
 #include <grpcpp/grpcpp.h>
 #include <silkworm/common/log.hpp>
 
-#include <silkrpc/common/log.hpp>
-
 namespace silkrpc {
 
 using Catch::Matchers::Message;
@@ -88,7 +86,7 @@ TEST_CASE("Context", "[silkrpc][context_pool]") {
         SECTION(std::string("Context::Context wait_mode=") + std::to_string(static_cast<int>(wait_mode))) {
             Context context{create_channel, std::make_shared<BlockCache>(), wait_mode};
             CHECK_NOTHROW(context.io_context() != nullptr);
-            CHECK_NOTHROW(context.rpc_end_point() != nullptr);
+            CHECK_NOTHROW(context.grpc_context() != nullptr);
             CHECK_NOTHROW(context.backend() != nullptr);
             CHECK_NOTHROW(context.miner() != nullptr);
             CHECK_NOTHROW(context.block_cache() != nullptr);

--- a/silkrpc/ethbackend/backend_grpc.cpp
+++ b/silkrpc/ethbackend/backend_grpc.cpp
@@ -43,7 +43,7 @@ BackEndGrpc::~BackEndGrpc() {
 
 boost::asio::awaitable<evmc::address> BackEndGrpc::etherbase() {
     const auto start_time = clock_time::now();
-    auto eb_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncEtherbase>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncEtherbase> eb_rpc(*stub_, grpc_context_);
     const auto reply = co_await eb_rpc.finish_on(executor_, ::remote::EtherbaseRequest{});
     evmc::address evmc_address;
     if (reply.has_address()) {
@@ -56,7 +56,7 @@ boost::asio::awaitable<evmc::address> BackEndGrpc::etherbase() {
 
 boost::asio::awaitable<uint64_t> BackEndGrpc::protocol_version() {
     const auto start_time = clock_time::now();
-    auto pv_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncProtocolVersion>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncProtocolVersion> pv_rpc(*stub_, grpc_context_);
     const auto reply = co_await pv_rpc.finish_on(executor_, ::remote::ProtocolVersionRequest{});
     const auto pv = reply.id();
     SILKRPC_DEBUG << "BackEnd::protocol_version version=" << pv << " t=" << clock_time::since(start_time) << "\n";
@@ -65,7 +65,7 @@ boost::asio::awaitable<uint64_t> BackEndGrpc::protocol_version() {
 
 boost::asio::awaitable<uint64_t> BackEndGrpc::net_version() {
     const auto start_time = clock_time::now();
-    auto nv_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncNetVersion>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncNetVersion> nv_rpc(*stub_, grpc_context_);
     const auto reply = co_await nv_rpc.finish_on(executor_, ::remote::NetVersionRequest{});
     const auto nv = reply.id();
     SILKRPC_DEBUG << "BackEnd::net_version version=" << nv << " t=" << clock_time::since(start_time) << "\n";
@@ -74,7 +74,7 @@ boost::asio::awaitable<uint64_t> BackEndGrpc::net_version() {
 
 boost::asio::awaitable<std::string> BackEndGrpc::client_version() {
     const auto start_time = clock_time::now();
-    auto cv_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncClientVersion>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncClientVersion> cv_rpc(*stub_, grpc_context_);
     const auto reply = co_await cv_rpc.finish_on(executor_, ::remote::ClientVersionRequest{});
     const auto cv = reply.nodename();
     SILKRPC_DEBUG << "BackEnd::client_version version=" << cv << " t=" << clock_time::since(start_time) << "\n";
@@ -83,7 +83,7 @@ boost::asio::awaitable<std::string> BackEndGrpc::client_version() {
 
 boost::asio::awaitable<uint64_t> BackEndGrpc::net_peer_count() {
     const auto start_time = clock_time::now();
-    auto npc_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncNetPeerCount>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncNetPeerCount> npc_rpc(*stub_, grpc_context_);
     const auto reply = co_await npc_rpc.finish_on(executor_, ::remote::NetPeerCountRequest{});
     const auto count = reply.count();
     SILKRPC_DEBUG << "BackEnd::net_peer_count count=" << count << " t=" << clock_time::since(start_time) << "\n";
@@ -92,7 +92,7 @@ boost::asio::awaitable<uint64_t> BackEndGrpc::net_peer_count() {
 
 boost::asio::awaitable<ExecutionPayload> BackEndGrpc::engine_get_payload_v1(uint64_t payload_id) {
     const auto start_time = clock_time::now();
-    auto npc_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineGetPayloadV1>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineGetPayloadV1> npc_rpc(*stub_, grpc_context_);
     ::remote::EngineGetPayloadRequest req;
     req.set_payloadid(payload_id);
     const auto reply = co_await npc_rpc.finish_on(executor_, req);
@@ -103,7 +103,7 @@ boost::asio::awaitable<ExecutionPayload> BackEndGrpc::engine_get_payload_v1(uint
 
 boost::asio::awaitable<PayloadStatus> BackEndGrpc::engine_new_payload_v1(ExecutionPayload payload) {
     const auto start_time = clock_time::now();
-    auto npc_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineNewPayloadV1>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineNewPayloadV1> npc_rpc(*stub_, grpc_context_);
     auto req{encode_execution_payload(payload)};
     const auto reply = co_await npc_rpc.finish_on(executor_, req);
     PayloadStatus payload_status = decode_payload_status(reply);
@@ -113,7 +113,7 @@ boost::asio::awaitable<PayloadStatus> BackEndGrpc::engine_new_payload_v1(Executi
 
 boost::asio::awaitable<ForkchoiceUpdatedReply> BackEndGrpc::engine_forkchoice_updated_v1(ForkchoiceUpdatedRequest forkchoice_updated_request) {
     const auto start_time = clock_time::now();
-    auto fcu_rpc = silkrpc::make_unary_rpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineForkChoiceUpdatedV1>(*stub_, grpc_context_);
+    silkrpc::UnaryRpc<&::remote::ETHBACKEND::StubInterface::AsyncEngineForkChoiceUpdatedV1> fcu_rpc(*stub_, grpc_context_);
     const auto req{encode_forkchoice_updated_request(forkchoice_updated_request)};
     const auto reply = co_await fcu_rpc.finish_on(executor_, req);
     PayloadStatus payload_status = decode_payload_status(reply.payloadstatus());

--- a/silkrpc/ethbackend/backend_grpc.cpp
+++ b/silkrpc/ethbackend/backend_grpc.cpp
@@ -22,9 +22,10 @@
 #include <boost/endian/conversion.hpp>
 #include <grpcpp/grpcpp.h>
 
-#include <silkrpc/grpc/awaitables.hpp>
+#include <silkrpc/grpc/unary_rpc.hpp>
 #include <silkrpc/common/clock_time.hpp>
 #include <silkrpc/common/log.hpp>
+#include <silkrpc/common/util.hpp>
 #include <silkrpc/config.hpp>
 
 namespace silkrpc::ethbackend {

--- a/silkrpc/ethbackend/backend_grpc.hpp
+++ b/silkrpc/ethbackend/backend_grpc.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <memory>
 
-#include <agrpc/grpcContext.hpp>
+#include <agrpc/grpc_context.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <evmc/evmc.hpp>

--- a/silkrpc/ethbackend/backend_grpc.hpp
+++ b/silkrpc/ethbackend/backend_grpc.hpp
@@ -21,12 +21,11 @@
 #include <string>
 #include <memory>
 
+#include <agrpc/grpcContext.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <evmc/evmc.hpp>
 
-#include <silkrpc/grpc/awaitables.hpp>
-#include <silkrpc/grpc/async_unary_client.hpp>
 #include <silkrpc/interfaces/remote/ethbackend.grpc.pb.h>
 #include <silkrpc/interfaces/types/types.pb.h>
 #include <silkrpc/types/execution_payload.hpp>
@@ -34,139 +33,13 @@
 
 namespace silkrpc::ethbackend {
 
-using EtherbaseClient = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EtherbaseRequest,
-    ::remote::EtherbaseReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncEtherbase
->;
-
-using ProtocolVersionClient = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::ProtocolVersionRequest,
-    ::remote::ProtocolVersionReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncProtocolVersion
->;
-
-using NetVersionClient = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::NetVersionRequest,
-    ::remote::NetVersionReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncNetVersion
->;
-
-using ClientVersionClient = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::ClientVersionRequest,
-    ::remote::ClientVersionReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncClientVersion
->;
-
-using NetPeerCountClient = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::NetPeerCountRequest,
-    ::remote::NetPeerCountReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncNetPeerCount
->;
-
-using EngineGetPayloadV1Client = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EngineGetPayloadRequest,
-    ::types::ExecutionPayload,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncEngineGetPayloadV1
->;
-
-using EngineNewPayloadV1Client = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::types::ExecutionPayload,
-    ::remote::EnginePayloadStatus,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncEngineNewPayloadV1
->;
-
-using EngineForkChoiceUpdatedV1Client = AsyncUnaryClient<
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EngineForkChoiceUpdatedRequest,
-    ::remote::EngineForkChoiceUpdatedReply,
-    &::remote::ETHBACKEND::StubInterface::PrepareAsyncEngineForkChoiceUpdatedV1
->;
-
-using EtherbaseAwaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    EtherbaseClient,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EtherbaseRequest,
-    ::remote::EtherbaseReply
->;
-
-using ProtocolVersionAwaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    ProtocolVersionClient,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::ProtocolVersionRequest,
-    ::remote::ProtocolVersionReply
->;
-
-using NetVersionAwaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    NetVersionClient,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::NetVersionRequest,
-    ::remote::NetVersionReply
->;
-
-using ClientVersionAwaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    ClientVersionClient,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::ClientVersionRequest,
-    ::remote::ClientVersionReply
->;
-
-using NetPeerCountAwaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    NetPeerCountClient,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::NetPeerCountRequest,
-    ::remote::NetPeerCountReply
->;
-
-using EngineGetPayloadV1Awaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    EngineGetPayloadV1Client,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EngineGetPayloadRequest,
-    ::types::ExecutionPayload
->;
-
-using EngineNewPayloadV1Awaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    EngineNewPayloadV1Client,
-    ::remote::ETHBACKEND::StubInterface,
-    ::types::ExecutionPayload,
-    ::remote::EnginePayloadStatus
->;
-
-using EngineForkChoiceUpdatedV1Awaitable = unary_awaitable<
-    boost::asio::io_context::executor_type,
-    EngineForkChoiceUpdatedV1Client,
-    ::remote::ETHBACKEND::StubInterface,
-    ::remote::EngineForkChoiceUpdatedRequest,
-    ::remote::EngineForkChoiceUpdatedReply
->;
-
 class BackEndGrpc final: public BackEnd {
 public:
-    explicit BackEndGrpc(boost::asio::io_context& context, std::shared_ptr<grpc::Channel> channel, grpc::CompletionQueue* queue)
-    : BackEndGrpc(context.get_executor(), ::remote::ETHBACKEND::NewStub(channel), queue) {}
+    explicit BackEndGrpc(boost::asio::io_context& context, std::shared_ptr<grpc::Channel> channel, agrpc::GrpcContext& grpc_context);
 
-    explicit BackEndGrpc(boost::asio::io_context::executor_type executor, std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub, grpc::CompletionQueue* queue)
-    : executor_(executor), stub_(std::move(stub)), queue_(queue) {
-        SILKRPC_TRACE << "BackEnd::ctor " << this << "\n";
-    }
+    explicit BackEndGrpc(boost::asio::io_context::executor_type executor, std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub, agrpc::GrpcContext& grpc_context);
 
-    ~BackEndGrpc() {
-        SILKRPC_TRACE << "BackEnd::dtor " << this << "\n";
-    }
+    ~BackEndGrpc();
 
     boost::asio::awaitable<evmc::address> etherbase();
     boost::asio::awaitable<uint64_t> protocol_version();
@@ -204,7 +77,7 @@ private:
 
     boost::asio::io_context::executor_type executor_;
     std::unique_ptr<::remote::ETHBACKEND::StubInterface> stub_;
-    grpc::CompletionQueue* queue_;
+    agrpc::GrpcContext& grpc_context_;
 };
 
 } // namespace silkrpc::ethbackend

--- a/silkrpc/ethdb/kv/remote_cursor.cpp
+++ b/silkrpc/ethdb/kv/remote_cursor.cpp
@@ -93,4 +93,103 @@ boost::asio::awaitable<void> RemoteCursor::close_cursor() {
     co_return;
 }
 
+boost::asio::awaitable<void> RemoteCursor2::open_cursor(const std::string& table_name) {
+    const auto start_time = clock_time::now();
+    if (cursor_id_ == 0) {
+        SILKRPC_DEBUG << "RemoteCursor::open_cursor opening new cursor for table: " << table_name << "\n";
+        auto open_message = remote::Cursor{};
+        open_message.set_op(remote::Op::OPEN);
+        open_message.set_bucketname(table_name);
+        cursor_id_ = (co_await streaming_rpc_.write_and_read(open_message)).cursorid();
+        SILKRPC_DEBUG << "RemoteCursor::open_cursor cursor: " << cursor_id_ << " for table: " << table_name << "\n";
+    }
+    SILKRPC_DEBUG << "RemoteCursor::open_cursor [" << table_name << "] c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return;
+}
+
+boost::asio::awaitable<KeyValue> RemoteCursor2::seek(silkworm::ByteView key) {
+    const auto start_time = clock_time::now();
+    SILKRPC_DEBUG << "RemoteCursor::seek cursor: " << cursor_id_ << " key: " << key << "\n";
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK);
+    seek_message.set_cursor(cursor_id_);
+    seek_message.set_k(key.data(), key.length());
+    auto seek_pair = co_await streaming_rpc_.write_and_read(seek_message);
+    const auto k = silkworm::bytes_of_string(seek_pair.k());
+    const auto v = silkworm::bytes_of_string(seek_pair.v());
+    SILKRPC_DEBUG << "RemoteCursor::seek k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return KeyValue{k, v};
+}
+
+boost::asio::awaitable<KeyValue> RemoteCursor2::seek_exact(silkworm::ByteView key) {
+    const auto start_time = clock_time::now();
+    SILKRPC_DEBUG << "RemoteCursor::seek_exact cursor: " << cursor_id_ << " key: " << key << "\n";
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK_EXACT);
+    seek_message.set_cursor(cursor_id_);
+    seek_message.set_k(key.data(), key.length());
+    auto seek_pair = co_await streaming_rpc_.write_and_read(seek_message);
+    const auto k = silkworm::bytes_of_string(seek_pair.k());
+    const auto v = silkworm::bytes_of_string(seek_pair.v());
+    SILKRPC_DEBUG << "RemoteCursor::seek_exact k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return KeyValue{k, v};
+}
+
+boost::asio::awaitable<KeyValue> RemoteCursor2::next() {
+    const auto start_time = clock_time::now();
+    auto next_message = remote::Cursor{};
+    next_message.set_op(remote::Op::NEXT);
+    next_message.set_cursor(cursor_id_);
+    auto next_pair = co_await streaming_rpc_.write_and_read(next_message);
+    const auto k = silkworm::bytes_of_string(next_pair.k());
+    const auto v = silkworm::bytes_of_string(next_pair.v());
+    SILKRPC_DEBUG << "RemoteCursor::next k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return KeyValue{k, v};
+}
+
+boost::asio::awaitable<silkworm::Bytes> RemoteCursor2::seek_both(silkworm::ByteView key, silkworm::ByteView value) {
+    const auto start_time = clock_time::now();
+    SILKRPC_DEBUG << "RemoteCursor::seek_both cursor: " << cursor_id_ << " key: " << key << " subkey: " << value << "\n";
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK_BOTH);
+    seek_message.set_cursor(cursor_id_);
+    seek_message.set_k(key.data(), key.length());
+    seek_message.set_v(value.data(), value.length());
+    auto seek_pair = co_await streaming_rpc_.write_and_read(seek_message);
+    const auto k = silkworm::bytes_of_string(seek_pair.k());
+    const auto v = silkworm::bytes_of_string(seek_pair.v());
+    SILKRPC_DEBUG << "RemoteCursor::seek_both k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return v;
+}
+
+boost::asio::awaitable<KeyValue> RemoteCursor2::seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) {
+    const auto start_time = clock_time::now();
+    SILKRPC_DEBUG << "RemoteCursor::seek_both_exact cursor: " << cursor_id_ << " key: " << key << " subkey: " << value << "\n";
+    auto seek_message = remote::Cursor{};
+    seek_message.set_op(remote::Op::SEEK_BOTH_EXACT);
+    seek_message.set_cursor(cursor_id_);
+    seek_message.set_k(key.data(), key.length());
+    seek_message.set_v(value.data(), value.length());
+    auto seek_pair = co_await streaming_rpc_.write_and_read(seek_message);
+    const auto k = silkworm::bytes_of_string(seek_pair.k());
+    const auto v = silkworm::bytes_of_string(seek_pair.v());
+    SILKRPC_DEBUG << "RemoteCursor::seek_both_exact k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time) << "\n";
+    co_return KeyValue{k, v};
+}
+
+boost::asio::awaitable<void> RemoteCursor2::close_cursor() {
+    const auto start_time = clock_time::now();
+    const auto cursor_id = cursor_id_;
+    if (cursor_id_ != 0) {
+        SILKRPC_DEBUG << "RemoteCursor::close_cursor closing cursor: " << cursor_id_ << "\n";
+        auto close_message = remote::Cursor{};
+        close_message.set_op(remote::Op::CLOSE);
+        close_message.set_cursor(cursor_id_);
+        co_await streaming_rpc_.write_and_read(close_message);
+        SILKRPC_DEBUG << "RemoteCursor::close_cursor cursor: " << cursor_id_ << "\n";
+        cursor_id_ = 0;
+    }
+    SILKRPC_DEBUG << "RemoteCursor::close_cursor c=" << cursor_id << " t=" << clock_time::since(start_time) << "\n";
+    co_return;
+}
 } // namespace silkrpc::ethdb::kv

--- a/silkrpc/ethdb/kv/remote_cursor.hpp
+++ b/silkrpc/ethdb/kv/remote_cursor.hpp
@@ -66,7 +66,7 @@ private:
     uint32_t cursor_id_;
 };
 
-using KVStreamingRpc = silkrpc::BidiStreamingRpc<&remote::KV::StubInterface::AsyncTx>;
+using KVStreamingRpc = silkrpc::BidiStreamingRpc<&remote::KV::StubInterface::PrepareAsyncTx>;
 
 class RemoteCursor2 : public CursorDupSort {
 public:

--- a/silkrpc/ethdb/kv/remote_cursor.hpp
+++ b/silkrpc/ethdb/kv/remote_cursor.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/io_context.hpp>
@@ -31,6 +32,8 @@
 #include <silkrpc/common/util.hpp>
 #include <silkrpc/ethdb/kv/awaitables.hpp>
 #include <silkrpc/ethdb/cursor.hpp>
+#include <silkrpc/grpc/bidi_streaming_rpc.hpp>
+#include <silkrpc/interfaces/remote/kv.grpc.pb.h>
 
 namespace silkrpc::ethdb::kv {
 
@@ -60,6 +63,34 @@ public:
 
 private:
     KvAsioAwaitable<boost::asio::io_context::executor_type>& kv_awaitable_;
+    uint32_t cursor_id_;
+};
+
+using KVStreamingRpc = silkrpc::BidiStreamingRpc<&remote::KV::StubInterface::AsyncTx>;
+
+class RemoteCursor2 : public CursorDupSort {
+public:
+    explicit RemoteCursor2(KVStreamingRpc& streaming_rpc)
+    : streaming_rpc_(streaming_rpc), cursor_id_{0} {}
+
+    uint32_t cursor_id() const override { return cursor_id_; };
+
+    boost::asio::awaitable<void> open_cursor(const std::string& table_name) override;
+
+    boost::asio::awaitable<KeyValue> seek(silkworm::ByteView key) override;
+
+    boost::asio::awaitable<KeyValue> seek_exact(silkworm::ByteView key) override;
+
+    boost::asio::awaitable<KeyValue> next() override;
+
+    boost::asio::awaitable<void> close_cursor() override;
+
+    boost::asio::awaitable<silkworm::Bytes> seek_both(silkworm::ByteView key, silkworm::ByteView value) override;
+
+    boost::asio::awaitable<KeyValue> seek_both_exact(silkworm::ByteView key, silkworm::ByteView value) override;
+
+private:
+    KVStreamingRpc& streaming_rpc_;
     uint32_t cursor_id_;
 };
 

--- a/silkrpc/ethdb/kv/remote_transaction.cpp
+++ b/silkrpc/ethdb/kv/remote_transaction.cpp
@@ -1,0 +1,71 @@
+/*
+    Copyright 2020 The Silkrpc Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <utility>
+
+#include <silkrpc/config.hpp>
+
+#include <boost/asio/use_awaitable.hpp>
+#include <grpcpp/grpcpp.h>
+
+#include <silkrpc/common/log.hpp>
+#include <silkrpc/ethdb/kv/remote_transaction.hpp>
+
+namespace silkrpc::ethdb::kv {
+
+RemoteTransaction2::RemoteTransaction2(remote::KV::StubInterface& stub, agrpc::GrpcContext& grpc_context)
+    : streaming_rpc_{stub, grpc_context} {
+        SILKRPC_TRACE << "RemoteTransaction::ctor " << this << " start\n";
+        SILKRPC_TRACE << "RemoteTransaction::ctor " << this << " end\n";
+    }
+
+RemoteTransaction2::~RemoteTransaction2() {
+    SILKRPC_TRACE << "RemoteTransaction::dtor " << this << " start\n";
+    SILKRPC_TRACE << "RemoteTransaction::dtor " << this << " end\n";
+}
+
+boost::asio::awaitable<void> RemoteTransaction2::open() {
+    tx_id_ = (co_await streaming_rpc_.request_and_read()).txid();
+    co_return;
+}
+
+boost::asio::awaitable<std::shared_ptr<Cursor>> RemoteTransaction2::cursor(const std::string& table) {
+    co_return co_await get_cursor(table);
+}
+
+boost::asio::awaitable<std::shared_ptr<CursorDupSort>> RemoteTransaction2::cursor_dup_sort(const std::string& table) {
+    co_return co_await get_cursor(table);
+}
+
+boost::asio::awaitable<void> RemoteTransaction2::close() {
+    cursors_.clear();
+    co_await streaming_rpc_.writes_done_and_finish();
+    co_return;
+}
+
+boost::asio::awaitable<std::shared_ptr<CursorDupSort>> RemoteTransaction2::get_cursor(const std::string& table) {
+    auto cursor_it = cursors_.find(table);
+    if (cursor_it != cursors_.end()) {
+        co_return cursor_it->second;
+    }
+    auto cursor = std::make_shared<RemoteCursor2>(streaming_rpc_);
+    co_await cursor->open_cursor(table);
+    cursors_[table] = cursor;
+    co_return cursor;
+}
+
+} // namespace silkrpc::ethdb::kv
+

--- a/silkrpc/ethdb/kv/remote_transaction.hpp
+++ b/silkrpc/ethdb/kv/remote_transaction.hpp
@@ -21,11 +21,13 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #include <silkrpc/config.hpp>
 
 #include <boost/asio/use_awaitable.hpp>
 #include <grpcpp/grpcpp.h>
+#include <agrpc/grpcContext.hpp>
 
 #include <silkrpc/common/log.hpp>
 #include <silkrpc/ethdb/cursor.hpp>
@@ -90,6 +92,30 @@ private:
     boost::asio::io_context& context_;
     Client client_;
     KvAsioAwaitable<boost::asio::io_context::executor_type> kv_awaitable_;
+    std::map<std::string, std::shared_ptr<CursorDupSort>> cursors_;
+    uint64_t tx_id_;
+};
+
+class RemoteTransaction2 : public Transaction {
+public:
+    explicit RemoteTransaction2(remote::KV::StubInterface& stub, agrpc::GrpcContext& grpc_context);
+
+    ~RemoteTransaction2();
+
+    uint64_t tx_id() const override { return tx_id_; }
+
+    boost::asio::awaitable<void> open() override;
+
+    boost::asio::awaitable<std::shared_ptr<Cursor>> cursor(const std::string& table) override;
+
+    boost::asio::awaitable<std::shared_ptr<CursorDupSort>> cursor_dup_sort(const std::string& table) override;
+
+    boost::asio::awaitable<void> close() override;
+
+private:
+    boost::asio::awaitable<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table);
+
+    silkrpc::ethdb::kv::KVStreamingRpc streaming_rpc_;
     std::map<std::string, std::shared_ptr<CursorDupSort>> cursors_;
     uint64_t tx_id_;
 };

--- a/silkrpc/ethdb/kv/remote_transaction.hpp
+++ b/silkrpc/ethdb/kv/remote_transaction.hpp
@@ -27,7 +27,7 @@
 
 #include <boost/asio/use_awaitable.hpp>
 #include <grpcpp/grpcpp.h>
-#include <agrpc/grpcContext.hpp>
+#include <agrpc/grpc_context.hpp>
 
 #include <silkrpc/common/log.hpp>
 #include <silkrpc/ethdb/cursor.hpp>

--- a/silkrpc/ethdb/kv/remote_transaction_test.cpp
+++ b/silkrpc/ethdb/kv/remote_transaction_test.cpp
@@ -535,9 +535,9 @@ struct RemoteTransactionTest : test::KVTestBase {
 
 TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction2::open", "[silkrpc][ethdb][kv][remote_transaction]") {
     SECTION("request fails") {
-        EXPECT_CALL(*stub_, AsyncTxRaw).WillOnce([&](auto&&, auto&&, void* tag) {
+        EXPECT_CALL(*stub_, PrepareAsyncTxRaw).WillOnce(Return(reader_writer_ptr_.release()));        
+        EXPECT_CALL(reader_writer_, StartCall).WillOnce([&](void* tag) {
             agrpc::process_grpc_tag(grpc_context_, tag, false);
-            return reader_writer_ptr_.release();
         });
         EXPECT_CALL(reader_writer_, Finish).WillOnce([&](grpc::Status* status, void* tag) {
             *status = grpc::Status::CANCELLED;

--- a/silkrpc/grpc/awaitables.hpp
+++ b/silkrpc/grpc/awaitables.hpp
@@ -23,16 +23,18 @@
 #include <memory>
 #include <string>
 #include <system_error>
-#include <thread>
 #include <utility>
 
+#include <agrpc/rpc.hpp>
 #include <boost/asio/async_result.hpp>
+#include <boost/asio/compose.hpp>
+#include <boost/asio/experimental/append.hpp>
 #include <boost/asio/detail/non_const_lvalue.hpp>
-#include <boost/asio/error.hpp>
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/common/util.hpp>
 #include <silkrpc/common/constants.hpp>
+#include <silkrpc/common/log.hpp>
 #include <silkrpc/common/util.hpp>
 #include <silkrpc/grpc/error.hpp>
 #include <silkrpc/grpc/async_operation.hpp>
@@ -130,22 +132,106 @@ struct unary_awaitable {
     UnaryClient client_;
 };
 
-template<typename Executor, typename UnaryClient, typename StubInterface, typename Request>
-struct unary_awaitable<Executor, UnaryClient, StubInterface, Request, void> {
-    typedef Executor executor_type;
+namespace detail {
+struct DoneTag {
+};
 
-    explicit unary_awaitable(const Executor& executor, std::unique_ptr<StubInterface>& stub, grpc::CompletionQueue* queue)
-    : executor_(executor), client_{stub, queue} {}
+template<typename Executor>
+struct ExecutorDispatcher {
+    Executor executor_;
 
-    template<typename WaitHandler>
-    auto async_call(const Request& request, WaitHandler&& handler) {
-        return boost::asio::async_initiate<WaitHandler, void(boost::system::error_code)>(
-            initiate_unary_async<Executor, UnaryClient, async_reply_operation, StubInterface, Request, void>{this, request}, handler);
+    template<typename CompletionToken, typename... Args>
+    void dispatch(CompletionToken&& token, Args&&... args){
+                boost::asio::dispatch(boost::asio::bind_executor(executor_, boost::asio::experimental::append(std::forward<CompletionToken>(token), std::forward<Args>(args)...)));
+
+    }
+};   
+    
+struct InlineDispatcher {
+    template<typename CompletionToken, typename... Args>
+    void dispatch(CompletionToken&& token, Args&&... args){
+            std::forward<CompletionToken>(token)(std::forward<Args>(args)...);
+
+    }
+};
+}
+
+template<auto Rpc, typename Stub>
+class UnaryRpc;
+
+template<
+    typename Stub,
+    typename StubBase,
+    typename Request,
+    template<typename> typename Reader,
+    typename Reply,
+    std::unique_ptr<Reader<Reply>>(StubBase::*Async)(grpc::ClientContext*, const Request&, grpc::CompletionQueue*)
+>
+class UnaryRpc<Async, Stub> {
+private:
+    template<typename Dispatcher>
+    struct Call {
+        UnaryRpc& self_;
+        const Request& request_;
+        [[no_unique_address]] Dispatcher dispatcher_;
+
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "UnaryRpc::async_call " << this << " start\n";
+            self_.reader_ = agrpc::request(Async, self_.stub_, self_.context_, request_, self_.grpc_context_);
+            agrpc::finish(self_.reader_, self_.reply_, self_.status_, 
+                boost::asio::bind_executor(self_.grpc_context_, std::move(op)));
+        }
+
+        template<typename Op>
+        void operator()(Op& op, bool /*ok*/) {
+            dispatcher_.dispatch(std::move(op), detail::DoneTag{});
+        }
+
+        template<typename Op>
+        void operator()(Op& op, detail::DoneTag) {
+            auto& status = self_.status_;
+            SILKRPC_TRACE << "UnaryRpc::completed result: " << status.ok() << "\n";
+            if (status.ok()) {
+                op.complete({}, std::move(self_.reply_));
+            } else {
+                SILKRPC_ERROR << "UnaryRpc::completed error_code: " << status.error_code() << "\n";
+                SILKRPC_ERROR << "UnaryRpc::completed error_message: " << status.error_message() << "\n";
+                SILKRPC_ERROR << "UnaryRpc::completed error_details: " << status.error_details() << "\n";
+                op.complete(make_error_code(status.error_code(), status.error_message()), {});
+            }
+        }
+    };
+
+public:
+    explicit UnaryRpc(Stub& stub, agrpc::GrpcContext& grpc_context)
+    : stub_(stub), grpc_context_(grpc_context) {}
+
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto finish(const Request& request, CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply)>(
+            Call<detail::InlineDispatcher>{*this, request}, token);
     }
 
-    const Executor& executor_;
-    UnaryClient client_;
+    template<typename Executor, typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto finish_on(const Executor& executor, const Request& request, CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply)>(
+            Call<detail::ExecutorDispatcher<Executor>>{*this, request, executor}, token, executor);
+    }
+
+private:
+    Stub& stub_;
+    agrpc::GrpcContext& grpc_context_;
+    grpc::ClientContext context_;
+    std::unique_ptr<Reader<Reply>> reader_;
+    Reply reply_;
+    grpc::Status status_;
 };
+
+template<auto Rpc, typename Stub>
+auto make_unary_rpc(Stub& stub, agrpc::GrpcContext& grpc_context) {
+    return UnaryRpc<Rpc, Stub>{stub, grpc_context};
+}
 
 } // namespace silkrpc
 

--- a/silkrpc/grpc/bidi_streaming_rpc.hpp
+++ b/silkrpc/grpc/bidi_streaming_rpc.hpp
@@ -47,9 +47,9 @@ template<
     typename Request,
     template<typename, typename> typename Responder,
     typename Reply,
-    std::unique_ptr<Responder<Request, Reply>>(Stub::*Async)(grpc::ClientContext*, grpc::CompletionQueue*, void*)
+    std::unique_ptr<Responder<Request, Reply>>(Stub::*PrepareAsync)(grpc::ClientContext*, grpc::CompletionQueue*)
 >
-class BidiStreamingRpc<Async> {
+class BidiStreamingRpc<PrepareAsync> {
 private:
      struct ReadNext {
         BidiStreamingRpc& self_;
@@ -83,7 +83,7 @@ private:
         template<typename Op>
         void operator()(Op& op) {
             SILKRPC_TRACE << "BidiStreamingRpc::RequestAndRead::initiate " << this << "\n";
-            agrpc::request(Async, this->self_.stub_, this->self_.context_, this->self_.reader_writer_, 
+            agrpc::request(PrepareAsync, this->self_.stub_, this->self_.context_, this->self_.reader_writer_, 
                 boost::asio::bind_executor(this->self_.grpc_context_, std::move(op)));
         }
 

--- a/silkrpc/grpc/bidi_streaming_rpc.hpp
+++ b/silkrpc/grpc/bidi_streaming_rpc.hpp
@@ -1,0 +1,187 @@
+/*
+    Copyright 2020 The Silkrpc Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef SILKRPC_GRPC_BIDI_STREAMING_RPC_HPP_
+#define SILKRPC_GRPC_BIDI_STREAMING_RPC_HPP_
+
+#include <silkrpc/config.hpp>
+
+#include <memory>
+#include <system_error>
+#include <utility>
+
+#include <agrpc/rpc.hpp>
+#include <boost/asio/compose.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/experimental/append.hpp>
+#include <grpcpp/grpcpp.h>
+
+#include <silkrpc/common/log.hpp>
+#include <silkrpc/grpc/error.hpp>
+
+namespace silkrpc {
+
+namespace detail {
+struct ReadDoneTag {
+};
+}
+
+template<auto Rpc>
+class BidiStreamingRpc;
+
+template<
+    typename Stub,
+    typename Request,
+    template<typename, typename> typename Responder,
+    typename Reply,
+    std::unique_ptr<Responder<Request, Reply>>(Stub::*Async)(grpc::ClientContext*, grpc::CompletionQueue*, void*)
+>
+class BidiStreamingRpc<Async> {
+private:
+     struct ReadNext {
+        BidiStreamingRpc& self_;
+
+        template<typename Op>
+        void operator()(Op& op, bool ok) {
+            if (ok) {
+                agrpc::read(self_.reader_writer_, self_.reply_, 
+                    boost::asio::bind_executor(self_.grpc_context_, boost::asio::experimental::append(std::move(op), detail::ReadDoneTag{})));
+            } else{
+                self_.finish(std::move(op));
+            }
+        }
+
+        template<typename Op>
+        void operator()(Op& op, bool ok, detail::ReadDoneTag) {
+            if (ok) {
+                op.complete({}, self_.reply_);
+            } else {
+                self_.finish(std::move(op));
+            }
+        }
+
+        template<typename Op>
+        void operator()(Op& op, const boost::system::error_code& ec) {
+            op.complete(ec, self_.reply_);
+        }
+    }; 
+
+    struct RequestAndRead : ReadNext {
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "BidiStreamingRpc::RequestAndRead::initiate " << this << "\n";
+            agrpc::request(Async, this->self_.stub_, this->self_.context_, this->self_.reader_writer_, 
+                boost::asio::bind_executor(this->self_.grpc_context_, std::move(op)));
+        }
+
+        using ReadNext::operator();
+    };    
+    
+    struct WriteAndRead : ReadNext {
+        const Request& request;
+
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "BidiStreamingRpc::WriteAndRead::initiate " << this << "\n";
+            agrpc::write(this->self_.reader_writer_, request, boost::asio::bind_executor(this->self_.grpc_context_, std::move(op)));
+        }
+
+        using ReadNext::operator();
+    };
+
+    struct WritesDoneAndFinish {
+        BidiStreamingRpc& self_;
+
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "BidiStreamingRpc::WritesDoneAndFinish::initiate " << this << "\n";
+            agrpc::writes_done(self_.reader_writer_, boost::asio::bind_executor(self_.grpc_context_, std::move(op)));
+        }
+
+        template<typename Op>
+        void operator()(Op& op, bool /*ok*/) {
+            self_.finish(std::move(op));
+        }
+
+        template<typename Op>
+        void operator()(Op& op, const boost::system::error_code& ec) {
+            op.complete(ec);
+        }
+    };
+
+    struct Finish {
+        BidiStreamingRpc& self_;
+
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "BidiStreamingRpc::Finish::initiate " << this << "\n";
+            agrpc::finish(self_.reader_writer_, self_.status_, boost::asio::bind_executor(self_.grpc_context_, std::move(op)));
+        }
+
+        template<typename Op>
+        void operator()(Op& op, bool /*ok*/) {
+            auto& status = self_.status_;
+            if (status.ok()) {
+                op.complete({});
+            } else {
+                SILKRPC_ERROR << "BidiStreamingRpc::Finish::completed error_code: " << status.error_code() << "\n";
+                SILKRPC_ERROR << "BidiStreamingRpc::Finish::completed error_message: " << status.error_message() << "\n";
+                SILKRPC_ERROR << "BidiStreamingRpc::Finish::completed error_details: " << status.error_details() << "\n";
+                op.complete(make_error_code(status.error_code(), status.error_message()));
+            }
+        }
+    };
+
+public:
+    explicit BidiStreamingRpc(Stub& stub, agrpc::GrpcContext& grpc_context)
+    : stub_(stub), grpc_context_(grpc_context) {}
+
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto request_and_read(CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply&)>(
+            RequestAndRead{*this}, token);
+    }
+
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto write_and_read(const Request& request, CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply&)>(
+            WriteAndRead{*this, request}, token);
+    }
+
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto writes_done_and_finish(CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code)>(
+            WritesDoneAndFinish{*this}, token);
+    }
+
+private:
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto finish(CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code)>(
+            Finish{*this}, token);
+    }
+
+    Stub& stub_;
+    agrpc::GrpcContext& grpc_context_;
+    grpc::ClientContext context_;
+    std::unique_ptr<Responder<Request, Reply>> reader_writer_;
+    Reply reply_;
+    grpc::Status status_;
+};
+
+} // namespace silkrpc::ethdb::kv
+
+#endif // SILKRPC_GRPC_BIDI_STREAMING_RPC_HPP_

--- a/silkrpc/grpc/bidi_streaming_rpc.hpp
+++ b/silkrpc/grpc/bidi_streaming_rpc.hpp
@@ -167,6 +167,10 @@ public:
             WritesDoneAndFinish{*this}, token);
     }
 
+    auto get_executor() const noexcept {
+        return grpc_context_.get_executor();
+    }
+
 private:
     template<typename CompletionToken = agrpc::DefaultCompletionToken>
     auto finish(CompletionToken&& token = {}) {

--- a/silkrpc/grpc/unary_rpc.hpp
+++ b/silkrpc/grpc/unary_rpc.hpp
@@ -1,0 +1,137 @@
+/*
+    Copyright 2020 The Silkrpc Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef SILKRPC_GRPC_UNARY_RPC_HPP_
+#define SILKRPC_GRPC_UNARY_RPC_HPP_
+
+#include <silkrpc/config.hpp>
+
+#include <memory>
+#include <system_error>
+#include <utility>
+
+#include <agrpc/rpc.hpp>
+#include <boost/asio/compose.hpp>
+#include <boost/asio/experimental/append.hpp>
+#include <grpcpp/grpcpp.h>
+
+#include <silkrpc/grpc/error.hpp>
+#include <silkrpc/common/log.hpp>
+
+namespace silkrpc {
+
+namespace detail {
+struct DoneTag {
+};
+
+template<typename Executor>
+struct ExecutorDispatcher {
+    Executor executor_;
+
+    template<typename CompletionToken, typename... Args>
+    void dispatch(CompletionToken&& token, Args&&... args){
+                boost::asio::dispatch(boost::asio::bind_executor(executor_, boost::asio::experimental::append(std::forward<CompletionToken>(token), std::forward<Args>(args)...)));
+
+    }
+};   
+    
+struct InlineDispatcher {
+    template<typename CompletionToken, typename... Args>
+    void dispatch(CompletionToken&& token, Args&&... args){
+            std::forward<CompletionToken>(token)(std::forward<Args>(args)...);
+
+    }
+};
+}
+
+template<auto Rpc>
+class UnaryRpc;
+
+template<
+    typename Stub,
+    typename Request,
+    template<typename> typename Reader,
+    typename Reply,
+    std::unique_ptr<Reader<Reply>>(Stub::*Async)(grpc::ClientContext*, const Request&, grpc::CompletionQueue*)
+>
+class UnaryRpc<Async> {
+private:
+    template<typename Dispatcher>
+    struct Call {
+        UnaryRpc& self_;
+        const Request& request_;
+        [[no_unique_address]] Dispatcher dispatcher_;
+
+        template<typename Op>
+        void operator()(Op& op) {
+            SILKRPC_TRACE << "UnaryRpc::initiate " << this << "\n";
+            self_.reader_ = agrpc::request(Async, self_.stub_, self_.context_, request_, self_.grpc_context_);
+            agrpc::finish(self_.reader_, self_.reply_, self_.status_, 
+                boost::asio::bind_executor(self_.grpc_context_, std::move(op)));
+        }
+
+        template<typename Op>
+        void operator()(Op& op, bool /*ok*/) {
+            dispatcher_.dispatch(std::move(op), detail::DoneTag{});
+        }
+
+        template<typename Op>
+        void operator()(Op& op, detail::DoneTag) {
+            auto& status = self_.status_;
+            SILKRPC_TRACE << "UnaryRpc::completed result: " << status.ok() << "\n";
+            if (status.ok()) {
+                op.complete({}, std::move(self_.reply_));
+            } else {
+                SILKRPC_ERROR << "UnaryRpc::completed error_code: " << status.error_code() << "\n";
+                SILKRPC_ERROR << "UnaryRpc::completed error_message: " << status.error_message() << "\n";
+                SILKRPC_ERROR << "UnaryRpc::completed error_details: " << status.error_details() << "\n";
+                op.complete(make_error_code(status.error_code(), status.error_message()), {});
+            }
+        }
+    };
+
+public:
+    explicit UnaryRpc(Stub& stub, agrpc::GrpcContext& grpc_context)
+    : stub_(stub), grpc_context_(grpc_context) {}
+
+    template<typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto finish(const Request& request, CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply)>(
+            Call<detail::InlineDispatcher>{*this, request}, token);
+    }
+
+    template<typename Executor, typename CompletionToken = agrpc::DefaultCompletionToken>
+    auto finish_on(const Executor& executor, const Request& request, CompletionToken&& token = {}) {
+        return boost::asio::async_compose<CompletionToken, void(boost::system::error_code, Reply)>(
+            Call<detail::ExecutorDispatcher<Executor>>{*this, request, executor}, token, executor);
+    }
+
+    auto get_executor() const noexcept {
+        return grpc_context_.get_executor();
+    }
+
+private:
+    Stub& stub_;
+    agrpc::GrpcContext& grpc_context_;
+    grpc::ClientContext context_;
+    std::unique_ptr<Reader<Reply>> reader_;
+    Reply reply_;
+    grpc::Status status_;
+};
+
+} // namespace silkrpc
+
+#endif // SILKRPC_GRPC_UNARY_RPC_HPP_

--- a/silkrpc/test/api_test_base.hpp
+++ b/silkrpc/test/api_test_base.hpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_API_TEST_BASE_HPP_
+#define SILKRPC_API_TEST_BASE_HPP_
+
+#include <memory>
+#include <silkrpc/config.hpp>
+#include <silkrpc/test/context_test_base.hpp>
+#include <utility>
+
+namespace silkrpc::test {
+
+template <typename Api, typename Stub>
+class ApiTestBase : public ContextTestBase {
+  public:
+    template <auto method, typename... Args>
+    auto run(Args&&... args) {
+        Api api{io_context_.get_executor(), std::move(stub_), grpc_context_};
+        return spawn_and_wait((api.*method)(std::forward<Args>(args)...));
+    }
+
+    std::unique_ptr<Stub> stub_{std::make_unique<Stub>()};
+};
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_API_TEST_BASE_HPP_

--- a/silkrpc/test/context_test_base.cpp
+++ b/silkrpc/test/context_test_base.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "context_test_base.hpp"
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_future.hpp>
+#include <memory>
+#include <silkrpc/common/log.hpp>
+#include <silkrpc/config.hpp>
+#include <silkrpc/context_pool.hpp>
+#include <utility>
+
+namespace silkrpc::test {
+
+ContextTestBase::ContextTestBase()
+    : init_dummy{[] {
+          SILKRPC_LOG_VERBOSITY(LogLevel::None);
+          return true;
+      }()},
+      context_{[]() { return grpc::CreateChannel("localhost:12345", grpc::InsecureChannelCredentials()); },
+               std::make_shared<BlockCache>()},
+      io_context_{*context_.io_context()},
+      grpc_context_{*context_.grpc_context()},
+      context_thread_{[&]() { context_.execute_loop(); }} {}
+
+ContextTestBase::~ContextTestBase() {
+    context_.stop();
+    if (context_thread_.joinable()) {
+        context_thread_.join();
+    }
+}
+
+}  // namespace silkrpc::test

--- a/silkrpc/test/context_test_base.hpp
+++ b/silkrpc/test/context_test_base.hpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_CONTEXT_TEST_BASE_HPP_
+#define SILKRPC_CONTEXT_TEST_BASE_HPP_
+
+#include <utility>
+#include <memory>
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_future.hpp>
+#include <silkrpc/config.hpp>
+#include <silkrpc/context_pool.hpp>
+
+namespace silkrpc::test {
+
+class ContextTestBase {
+  public:
+    ContextTestBase();
+
+    template <typename AwaitableOrFunction>
+    auto spawn_and_wait(AwaitableOrFunction&& awaitable) {
+        return boost::asio::co_spawn(io_context_, std::forward<AwaitableOrFunction>(awaitable), boost::asio::use_future)
+            .get();
+    }
+
+    ~ContextTestBase();
+
+  private:
+    bool init_dummy;
+
+  public:
+    Context context_;
+    boost::asio::io_context& io_context_;
+    agrpc::GrpcContext& grpc_context_;
+    std::thread context_thread_;
+};
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_CONTEXT_TEST_BASE_HPP_

--- a/silkrpc/test/grpc_actions.hpp
+++ b/silkrpc/test/grpc_actions.hpp
@@ -54,6 +54,10 @@ inline auto write_success(agrpc::GrpcContext& grpc_context) { return write(grpc_
 
 inline auto write_failure(agrpc::GrpcContext& grpc_context) { return write(grpc_context, false); }
 
+inline auto writes_done_success(agrpc::GrpcContext& grpc_context) {
+    return [&grpc_context](void* tag) { agrpc::process_grpc_tag(grpc_context, tag, true); };
+}
+
 template <typename Reply>
 auto read_success_with(agrpc::GrpcContext& grpc_context, Reply&& reply) {
     return [&grpc_context, reply = std::forward<Reply>(reply)](auto* reply_ptr, void* tag) mutable {

--- a/silkrpc/test/grpc_actions.hpp
+++ b/silkrpc/test/grpc_actions.hpp
@@ -1,0 +1,74 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_GRPC_ACTIONS_HPP_
+#define SILKRPC_GRPC_ACTIONS_HPP_
+
+#include <grpcpp/grpcpp.h>
+
+#include <agrpc/grpcContext.hpp>
+#include <agrpc/test.hpp>
+
+namespace silkrpc::test {
+
+inline auto finish_with_status(agrpc::GrpcContext& grpc_context, grpc::Status status) {
+    return [&grpc_context, status](auto&&, ::grpc::Status* status_ptr, void* tag) {
+        *status_ptr = status;
+        agrpc::process_grpc_tag(grpc_context, tag, true);
+    };
+}
+
+inline auto finish_ok(agrpc::GrpcContext& grpc_context) { return finish_with_status(grpc_context, grpc::Status::OK); }
+
+inline auto finish_cancelled(agrpc::GrpcContext& grpc_context) {
+    return finish_with_status(grpc_context, grpc::Status::CANCELLED);
+}
+
+template <typename Reply>
+auto finish_with(agrpc::GrpcContext& grpc_context, Reply&& reply) {
+    return [&grpc_context, reply = std::forward<Reply>(reply)](auto* reply_ptr, ::grpc::Status* status,
+                                                               void* tag) mutable {
+        *reply_ptr = std::move(reply);
+        finish_with_status(grpc_context, grpc::Status::OK)(reply_ptr, status, tag);
+    };
+}
+
+inline auto write(agrpc::GrpcContext& grpc_context, bool ok) {
+    return [&grpc_context, ok](auto&&, void* tag) { agrpc::process_grpc_tag(grpc_context, tag, ok); };
+}
+
+inline auto write_success(agrpc::GrpcContext& grpc_context) { return write(grpc_context, true); }
+
+inline auto write_failure(agrpc::GrpcContext& grpc_context) { return write(grpc_context, false); }
+
+template <typename Reply>
+auto read_success_with(agrpc::GrpcContext& grpc_context, Reply&& reply) {
+    return [&grpc_context, reply = std::forward<Reply>(reply)](auto* reply_ptr, void* tag) mutable {
+        *reply_ptr = std::move(reply);
+        agrpc::process_grpc_tag(grpc_context, tag, true);
+    };
+}
+
+inline auto finish_streaming_with_status(agrpc::GrpcContext& grpc_context, grpc::Status status) {
+    return [&grpc_context, status](::grpc::Status* status_ptr, void* tag) {
+        *status_ptr = status;
+        agrpc::process_grpc_tag(grpc_context, tag, true);
+    };
+}
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_GRPC_ACTIONS_HPP_

--- a/silkrpc/test/grpc_actions.hpp
+++ b/silkrpc/test/grpc_actions.hpp
@@ -19,7 +19,7 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include <agrpc/grpcContext.hpp>
+#include <agrpc/grpc_context.hpp>
 #include <agrpc/test.hpp>
 
 namespace silkrpc::test {

--- a/silkrpc/test/grpc_matcher.hpp
+++ b/silkrpc/test/grpc_matcher.hpp
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_GRPC_MATCHER_HPP_
+#define SILKRPC_GRPC_MATCHER_HPP_
+
+#include <grpcpp/grpcpp.h>
+
+#include <boost/system/system_error.hpp>
+#include <catch2/catch.hpp>
+
+namespace silkrpc::test {
+
+inline auto exception_has_grpc_status_code(grpc::StatusCode status_code) {
+    return Catch::Predicate<const boost::system::system_error&>(
+        [status_code](auto& e) { return std::error_code(e.code()).value() == status_code; });
+}
+
+inline auto exception_has_cancelled_grpc_status_code() {
+    return test::exception_has_grpc_status_code(grpc::StatusCode::CANCELLED);
+}
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_GRPC_MATCHER_HPP_

--- a/silkrpc/test/grpc_responder.hpp
+++ b/silkrpc/test/grpc_responder.hpp
@@ -1,0 +1,53 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_GRPC_RESPONDER_HPP_
+#define SILKRPC_GRPC_RESPONDER_HPP_
+
+#include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
+
+namespace silkrpc::test {
+
+template <typename Reply>
+class MockAsyncResponseReader : public grpc::ClientAsyncResponseReaderInterface<Reply> {
+  public:
+    MOCK_METHOD(void, StartCall, (), (override));
+    MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
+    MOCK_METHOD(void, Finish, (Reply*, ::grpc::Status*, void*), (override));
+};
+
+template <typename Reply>
+using StrictMockAsyncResponseReader = testing::StrictMock<MockAsyncResponseReader<Reply>>;
+
+template <typename Request, typename Reply>
+class MockAsyncReaderWriter : public grpc::ClientAsyncReaderWriterInterface<Request, Reply> {
+  public:
+    MOCK_METHOD(void, StartCall, (void*), (override));
+    MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
+    MOCK_METHOD(void, Read, (Reply*, void*), (override));
+    MOCK_METHOD(void, Write, (const Request&, void*), (override));
+    MOCK_METHOD(void, Write, (const Request&, ::grpc::WriteOptions, void*), (override));
+    MOCK_METHOD(void, WritesDone, (void*), (override));
+    MOCK_METHOD(void, Finish, (::grpc::Status*, void*), (override));
+};
+
+template <typename Request, typename Reply>
+using StrictMockAsyncReaderWriter = testing::StrictMock<MockAsyncReaderWriter<Request, Reply>>;
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_GRPC_RESPONDER_HPP_

--- a/silkrpc/test/kv_test_base.hpp
+++ b/silkrpc/test/kv_test_base.hpp
@@ -30,9 +30,9 @@ namespace silkrpc::test {
 
 struct KVTestBase : test::ContextTestBase {
     testing::Expectation expect_request_async_tx() {
-        return EXPECT_CALL(*stub_, AsyncTxRaw).WillOnce([&](auto&&, auto&&, void* tag) {
-            boost::asio::post(io_context_, [&, tag] { agrpc::process_grpc_tag(grpc_context_, tag, true); });
-            return reader_writer_ptr_.release();
+        EXPECT_CALL(*stub_, PrepareAsyncTxRaw).WillOnce(Return(reader_writer_ptr_.release()));        
+        return EXPECT_CALL(reader_writer_, StartCall).WillOnce([&](void* tag) {
+            agrpc::process_grpc_tag(grpc_context_, tag, true);
         });
     }
 

--- a/silkrpc/test/kv_test_base.hpp
+++ b/silkrpc/test/kv_test_base.hpp
@@ -17,19 +17,21 @@
 #ifndef SILKRPC_KV_TEST_BASE_HPP_
 #define SILKRPC_KV_TEST_BASE_HPP_
 
+#include <silkrpc/interfaces/remote/kv_mock.grpc.pb.h>
+
 #include <agrpc/test.hpp>
+#include <boost/asio/post.hpp>
 #include <memory>
 #include <silkrpc/config.hpp>
 #include <silkrpc/test/context_test_base.hpp>
 #include <silkrpc/test/grpc_responder.hpp>
-#include <silkrpc/interfaces/remote/kv_mock.grpc.pb.h>
 
 namespace silkrpc::test {
 
 struct KVTestBase : test::ContextTestBase {
     testing::Expectation expect_request_async_tx() {
         return EXPECT_CALL(*stub_, AsyncTxRaw).WillOnce([&](auto&&, auto&&, void* tag) {
-            agrpc::process_grpc_tag(grpc_context_, tag, true);
+            boost::asio::post(io_context_, [&, tag] { agrpc::process_grpc_tag(grpc_context_, tag, true); });
             return reader_writer_ptr_.release();
         });
     }

--- a/silkrpc/test/kv_test_base.hpp
+++ b/silkrpc/test/kv_test_base.hpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2020 The Silkrpc Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef SILKRPC_KV_TEST_BASE_HPP_
+#define SILKRPC_KV_TEST_BASE_HPP_
+
+#include <agrpc/test.hpp>
+#include <memory>
+#include <silkrpc/config.hpp>
+#include <silkrpc/test/context_test_base.hpp>
+#include <silkrpc/test/grpc_responder.hpp>
+#include <silkrpc/interfaces/remote/kv_mock.grpc.pb.h>
+
+namespace silkrpc::test {
+
+struct KVTestBase : test::ContextTestBase {
+    testing::Expectation expect_request_async_tx() {
+        return EXPECT_CALL(*stub_, AsyncTxRaw).WillOnce([&](auto&&, auto&&, void* tag) {
+            agrpc::process_grpc_tag(grpc_context_, tag, true);
+            return reader_writer_ptr_.release();
+        });
+    }
+
+    using StrictMockKVStub = testing::StrictMock<remote::MockKVStub>;
+    using StrictMockKVAsyncReaderWriter = test::StrictMockAsyncReaderWriter<remote::Cursor, remote::Pair>;
+
+    std::unique_ptr<StrictMockKVStub> stub_{std::make_unique<StrictMockKVStub>()};
+    std::unique_ptr<StrictMockKVAsyncReaderWriter> reader_writer_ptr_{
+        std::make_unique<StrictMockKVAsyncReaderWriter>()};
+    StrictMockKVAsyncReaderWriter& reader_writer_{*reader_writer_ptr_};
+};
+
+}  // namespace silkrpc::test
+
+#endif  // SILKRPC_KV_TEST_BASE_HPP_


### PR DESCRIPTION
https://github.com/torquem-ch/silkrpc/issues/204

I adjusted only the EthBackend to act as an example and reference for feedback. None of the other tests or main functions are expected to work.

Your feedback is now needed to decide whether the direction shown in this pr suits your plans. Also let me know whether I should refactor the streaming RPC as well, so you can get an idea on how it might look like.

It seems that you are not using clang-format for your code, so I did not know how to format my changes and kept them mostly ugly.

Highlights:

* Simplified protoc invocation through asio-grpc's `asio_grpc_protobuf_generate`
* Easier declaration of unary RPCs (no more `using XX = AsyncUnaryClient<...>`)
* Optionally switching to a different execution context upon completion of the RPC. Not sure whether it tis needed, but since the previous code was doing it, I put it in.
* Mocked stub in tests as an example to show how to simplify testing and make it more strict. Also makes it easier to run tests in parallel since no search for a free port is necessary.

---

There are a few local changes that I made to get things to compile:

* Add an include to `<utility>` in all places that use `asio::awaitable`. I think this only affects GCC12 and Boost.Asio pre 1.79.
* In `silkworm/cmake/Hunter/config.cmake` remove URL+SHA1 from re2 and CLI11.