### PR TITLE
Fix on trace_call output format

### DIFF
--- a/silkrpc/core/evm_trace.cpp
+++ b/silkrpc/core/evm_trace.cpp
@@ -437,8 +437,6 @@ void VmTraceTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stac
     TraceOp trace_op;
     trace_op.gas_cost = execution_state.gas_left;
     trace_op.idx = index_prefix;
-    // trace_op.idx = index_prefix_ + std::to_string(next_index_++);
-    // trace_op.idx = next_index_++;
     trace_op.op_code = op_code;
     trace_op.op_name = op_name == "KECCAK256" ? "SHA3" : op_name; // TODO(sixtysixter) for RPCDAEMON compatibility
     trace_op.pc = pc;

--- a/silkrpc/core/evm_trace.cpp
+++ b/silkrpc/core/evm_trace.cpp
@@ -57,7 +57,7 @@ void to_json(nlohmann::json& json, const VmTrace& vm_trace) {
 void to_json(nlohmann::json& json, const TraceOp& trace_op) {
     json["cost"] = trace_op.gas_cost;
     json["ex"] = trace_op.trace_ex;
-    json["idx"] = std::to_string(trace_op.idx);
+    json["idx"] = trace_op.idx;
     json["op"] = trace_op.op_name;
     json["pc"] = trace_op.pc;
     if (trace_op.sub) {
@@ -178,11 +178,7 @@ void to_json(nlohmann::json& json, const TraceCallTraces& result) {
     } else {
         json["stateDiff"] = nlohmann::json::value_t::null;
     }
-    if (result.trace.size() != 0) {
-        json["trace"] = result.trace;
-    } else {
-        json["trace"] = nlohmann::json::value_t::null;
-    }
+    json["trace"] = result.trace;
     if (result.vm_trace) {
         json["vmTrace"] = result.vm_trace.value();
     } else {
@@ -350,7 +346,14 @@ void push_memory_offset_len(std::uint8_t op_code, const evmone::uint256* stack, 
 
 std::string get_op_name(const char* const* names, std::uint8_t opcode) {
     const auto name = names[opcode];
-    return (name != nullptr) ?name : "opcode 0x" + evmc::hex(opcode) + " not defined";
+    if (name != nullptr) {
+        return name;
+     }
+    auto hex = evmc::hex(opcode);
+    if (opcode < 16) {
+        hex = hex.substr(1);
+    }
+    return "opcode 0x" + hex + " not defined";
 }
 
 std::string to_string(intx::uint256 value) {
@@ -380,8 +383,19 @@ void VmTraceTracer::on_execution_start(evmc_revision rev, const evmc_message& ms
     if (msg.depth == 0) {
         vm_trace_.code = "0x" + silkworm::to_hex(code);
         traces_stack_.push(vm_trace_);
+        if (transaction_index_ == -1) {
+            index_prefix_.push("");
+        } else {
+            index_prefix_.push(std::to_string(transaction_index_) + "-");
+        }
     } else if (vm_trace_.ops.size() > 0) {
-        auto& op = vm_trace_.ops[vm_trace_.ops.size() - 1];
+        auto& vm_trace = traces_stack_.top().get();
+
+        auto index_prefix = index_prefix_.top();
+        index_prefix = index_prefix + std::to_string(vm_trace.ops.size() - 1) + "-";
+        index_prefix_.push(index_prefix);
+
+        auto& op = vm_trace.ops[vm_trace.ops.size() - 1];
         op.sub = std::make_shared<VmTrace>();
         traces_stack_.push(*op.sub);
         op.sub->code = "0x" + silkworm::to_hex(code);
@@ -419,9 +433,13 @@ void VmTraceTracer::on_instruction_start(uint32_t pc , const intx::uint256 *stac
         copy_stack(op.op_code, stack_top, op.trace_ex.stack);
     }
 
+    auto index_prefix = index_prefix_.top() + std::to_string(vm_trace.ops.size());
+
     TraceOp trace_op;
     trace_op.gas_cost = execution_state.gas_left;
-    trace_op.idx = next_index_++;
+    trace_op.idx = index_prefix;
+    // trace_op.idx = index_prefix_ + std::to_string(next_index_++);
+    // trace_op.idx = next_index_++;
     trace_op.op_code = op_code;
     trace_op.op_name = op_name == "KECCAK256" ? "SHA3" : op_name; // TODO(sixtysixter) for RPCDAEMON compatibility
     trace_op.pc = pc;
@@ -452,6 +470,8 @@ void VmTraceTracer::on_execution_end(const evmc_result& result, const silkworm::
 
     std::uint64_t start_gas = start_gas_.top();
     start_gas_.pop();
+
+    index_prefix_.pop();
 
     SILKRPC_DEBUG << "VmTraceTracer::on_execution_end:"
         << " result.status_code: " << result.status_code
@@ -764,7 +784,7 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
             auto initial_code = initial_ibs_.get_code(address);
             auto initial_nonce = initial_ibs_.get_nonce(address);
             if (exists) {
-                bool all_equals = diff_storage.size() == 0;
+                bool all_equals = true;
                 auto final_balance = intra_block_state.get_balance(address);
                 if (initial_balance != final_balance) {
                     all_equals = false;
@@ -791,10 +811,15 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
                 }
                 for (auto& key : diff_storage) {
                     auto key_b32 = silkworm::bytes32_from_hex(key);
-                    entry.storage[key] = DiffValue{
-                        silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32)),
-                        silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32))
-                    };
+                    auto initial_storage = intra_block_state.get_original_storage(address, key_b32);
+                    auto final_storage = intra_block_state.get_current_storage(address, key_b32);
+                    if (initial_storage != final_storage) {
+                        all_equals = false;
+                        entry.storage[key] = DiffValue{
+                            silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32)),
+                            silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32))
+                        };
+                    }
                 }
                 if (all_equals) {
                     state_diff_.erase(address_key);
@@ -881,7 +906,7 @@ asio::awaitable<TraceCallResult> TraceCallExecutor<WorldState, VM>::execute(std:
     TraceCallTraces& traces = result.traces;
     if (config_.vm_trace) {
         traces.vm_trace.emplace();
-        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value());
+        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index);
         tracers.push_back(tracer);
     }
     if (config_.trace) {

--- a/silkrpc/core/evm_trace.cpp
+++ b/silkrpc/core/evm_trace.cpp
@@ -356,12 +356,11 @@ std::string get_op_name(const char* const* names, std::uint8_t opcode) {
     return "opcode 0x" + hex + " not defined";
 }
 
+static const char* PADDING = "0x0000000000000000000000000000000000000000000000000000000000000000";
 std::string to_string(intx::uint256 value) {
-    if (value != 0) {
-        return "0x" + intx::to_string(value, 16);
-    }
-
-    return "0x0000000000000000000000000000000000000000000000000000000000000000";
+    auto out = intx::to_string(value, 16);
+    std::string padding = std::string{PADDING};
+    return padding.substr(0, padding.size() - out.size()) + out;
 }
 
 void VmTraceTracer::on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept {

--- a/silkrpc/core/evm_trace.hpp
+++ b/silkrpc/core/evm_trace.hpp
@@ -78,7 +78,7 @@ struct TraceOp {
     std::uint64_t gas_cost{0};
     std::optional<std::uint64_t> call_gas;
     TraceEx trace_ex;
-    std::uint32_t idx;
+    std::string idx;
     std::uint8_t op_code;
     std::string op_name;
     std::uint32_t pc;
@@ -104,7 +104,7 @@ void push_memory_offset_len(std::uint8_t op_code, const evmone::uint256* stack, 
 
 class VmTraceTracer : public silkworm::EvmTracer {
 public:
-    explicit VmTraceTracer(VmTrace& vm_trace) : vm_trace_(vm_trace) {}
+    explicit VmTraceTracer(VmTrace& vm_trace, std::int32_t index = -1) : vm_trace_(vm_trace), transaction_index_{index} {}
 
     VmTraceTracer(const VmTraceTracer&) = delete;
     VmTraceTracer& operator=(const VmTraceTracer&) = delete;
@@ -118,9 +118,11 @@ public:
 
 private:
     VmTrace& vm_trace_;
+    std::int32_t transaction_index_;
+    std::stack<std::string> index_prefix_;
     std::stack<std::reference_wrapper<VmTrace>> traces_stack_;
     const char* const* opcode_names_ = nullptr;
-    std::int32_t next_index_{0};
+    // std::int32_t next_index_{0};
     std::stack<std::uint64_t> start_gas_;
     std::stack<TraceMemory> trace_memory_stack_;
 };

--- a/silkrpc/core/evm_trace.hpp
+++ b/silkrpc/core/evm_trace.hpp
@@ -124,7 +124,6 @@ private:
     std::stack<std::string> index_prefix_;
     std::stack<std::reference_wrapper<VmTrace>> traces_stack_;
     const char* const* opcode_names_ = nullptr;
-    // std::int32_t next_index_{0};
     std::stack<std::uint64_t> start_gas_;
     std::stack<TraceMemory> trace_memory_stack_;
 };

--- a/silkrpc/core/evm_trace.hpp
+++ b/silkrpc/core/evm_trace.hpp
@@ -52,6 +52,8 @@ struct TraceConfig {
 
 static const TraceConfig DEFAULT_TRACE_CONFIG{false, false, false};
 
+std::string get_op_name(const char* const* names, std::uint8_t opcode);
+std::string to_string(intx::uint256 value);
 std::ostream& operator<<(std::ostream& out, const TraceConfig& tc);
 
 struct TraceStorage {

--- a/silkrpc/core/evm_trace_test.cpp
+++ b/silkrpc/core/evm_trace_test.cpp
@@ -625,7 +625,7 @@ TEST_CASE("TraceCallExecutor::execute call 1") {
                 "storage": {}
                 }
             },
-            "trace": null,
+            "trace": [],
             "vmTrace": {
                 "code": "0x602a60005500",
                 "ops": [
@@ -894,7 +894,7 @@ TEST_CASE("TraceCallExecutor::execute call 1") {
         CHECK(result.traces == R"({
             "output": "0x",
             "stateDiff": null,
-            "trace": null,
+            "trace": [],
             "vmTrace": null
         })"_json);
     }
@@ -1469,7 +1469,7 @@ TEST_CASE("VmTrace json serialization") {
     TraceOp trace_op;
     trace_op.gas_cost = 42;
     trace_op.trace_ex = trace_ex;
-    trace_op.idx = 12;
+    trace_op.idx = "12";
     trace_op.op_name = "PUSH1";
     trace_op.pc = 27;
     VmTrace vm_trace;
@@ -1478,6 +1478,8 @@ TEST_CASE("VmTrace json serialization") {
     vm_trace.ops.push_back(trace_op);
 
     SECTION("VmTrace") {
+        nlohmann::json json = vm_trace;
+        std::cout << "JSON :" << json << "\n" << std::flush;
         CHECK(vm_trace == R"({
             "code": "0xdeadbeaf",
             "ops": [
@@ -1504,6 +1506,8 @@ TEST_CASE("VmTrace json serialization") {
         })"_json);
     }
     SECTION("TraceOp") {
+        nlohmann::json json = trace_op;
+        std::cout << "JSON :" << json << "\n" << std::flush;
         CHECK(trace_op == R"({
             "cost":42,
             "ex":{

--- a/silkrpc/core/evm_trace_test.cpp
+++ b/silkrpc/core/evm_trace_test.cpp
@@ -1478,8 +1478,6 @@ TEST_CASE("VmTrace json serialization") {
     vm_trace.ops.push_back(trace_op);
 
     SECTION("VmTrace") {
-        nlohmann::json json = vm_trace;
-        std::cout << "JSON :" << json << "\n" << std::flush;
         CHECK(vm_trace == R"({
             "code": "0xdeadbeaf",
             "ops": [
@@ -1506,8 +1504,6 @@ TEST_CASE("VmTrace json serialization") {
         })"_json);
     }
     SECTION("TraceOp") {
-        nlohmann::json json = trace_op;
-        std::cout << "JSON :" << json << "\n" << std::flush;
         CHECK(trace_op == R"({
             "cost":42,
             "ex":{
@@ -2070,6 +2066,59 @@ TEST_CASE("push_memory_offset_len") {
                 CHECK(tms.size() == 0);
                 break;
         }
+    }
+}
+TEST_CASE("get_op_name") {
+    SILKRPC_LOG_STREAMS(null_stream(), null_stream());
+    SILKRPC_LOG_VERBOSITY(LogLevel::None);
+    const char* names[256] = {
+    /* 0x00 */ "STOP",
+    /* 0x01 */ "ADD",
+    /* 0x02 */ "MUL",
+    /* 0x03 */ "SUB",
+    /* 0x04 */ "DIV",
+    /* 0x05 */ "SDIV",
+    /* 0x06 */ "MOD",
+    /* 0x07 */ "SMOD",
+    /* 0x08 */ "ADDMOD",
+    /* 0x09 */ "MULMOD",
+    /* 0x0a */ "EXP",
+    /* 0x0b */ "SIGNEXTEND",
+    /* 0x0c */ NULL,
+    /* 0x0d */ NULL,
+    /* 0x0e */ NULL,
+    /* 0x0f */ NULL,
+    /* 0x10 */ "LT",
+    /* 0x11 */ "GT",
+    /* 0x12 */ "SLT",
+    /* 0x13 */ "SGT",
+    /* 0x14 */ "EQ",
+    /* 0x15 */ "ISZERO",
+    /* 0x16 */ "AND"
+    };
+
+    SECTION("valid op_code") {
+        auto op_code_name = get_op_name(names, 0x00);
+        CHECK(op_code_name == "STOP");
+    }
+    SECTION("not existent op_code") {
+        auto op_code_name = get_op_name(names, 0x0d);
+        CHECK(op_code_name == "opcode 0xd not defined");
+    }
+}
+
+TEST_CASE("to_string") {
+    SECTION("value == 0") {
+        auto out = to_string(intx::uint256{0});
+        CHECK(out == "0x0000000000000000000000000000000000000000000000000000000000000000");
+    }
+    SECTION("value == 1") {
+        auto out = to_string(intx::uint256{1});
+        CHECK(out == "0x0000000000000000000000000000000000000000000000000000000000000001");
+    }
+    SECTION("value == 1") {
+        auto out = to_string(intx::uint256{0xdeadbeaf});
+        CHECK(out == "0x00000000000000000000000000000000000000000000000000000000deadbeaf");
     }
 }
 }  // namespace silkrpc::trace


### PR DESCRIPTION
Fix for:

- opcode len in `opcode not defined`  message
- index in `TraceOp` in case of subroutines
- bug in `vmTrace`  for subroutines
- result output when `trace` tracing is not required
- bug for output when storage doesn't change